### PR TITLE
Add support for state.show_highstate

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/modules/State.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/State.java
@@ -28,4 +28,8 @@ public class State {
         return apply(Arrays.asList(mods));
     }
 
+    public static LocalCall<Object> showHighstate() {
+        return new LocalCall<>("state.show_highstate", Optional.empty(), Optional.empty(),
+                new TypeToken<Object>() { });
+    }
 }


### PR DESCRIPTION
This patch adds support for [`state.show_highstate`] (https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.state.html#salt.modules.state.show_highstate), returning just an `Object` right now.