### PR TITLE
Better error handling for LocalCall results

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -123,8 +123,8 @@ public class LocalCall<R> implements Call<R> {
      * @return a map containing the results with the minion name as key
      * @throws SaltException if anything goes wrong
      */
-    public Map<String, Result<R>> callSync(final SaltClient client,
-                                           Target<?> target) throws SaltException {
+    public Map<String, Result<R>> callSync(final SaltClient client, Target<?> target)
+            throws SaltException {
         Map<String, Object> customArgs = new HashMap<>();
         customArgs.put("tgt", target.getTarget());
         customArgs.put("expr_form", target.getType());

--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -9,6 +9,8 @@ import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.results.Result;
 
 import com.google.gson.reflect.TypeToken;
+import com.suse.salt.netapi.results.SaltError;
+import com.suse.salt.netapi.utils.Xor;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
@@ -122,21 +124,21 @@ public class LocalCall<R> implements Call<R> {
      * @return a map containing the results with the minion name as key
      * @throws SaltException if anything goes wrong
      */
-    public Map<String, R> callSync(final SaltClient client, Target<?> target)
+    public Map<String, Xor<SaltError, R>> callSync(final SaltClient client, Target<?> target)
             throws SaltException {
         Map<String, Object> customArgs = new HashMap<>();
         customArgs.put("tgt", target.getTarget());
         customArgs.put("expr_form", target.getType());
 
-        Type type = parameterizedType(null, Map.class, String.class,
-                getReturnType().getType());
-        Type listType = parameterizedType(null, List.class, type);
+        Type xor = parameterizedType(null, Xor.class, SaltError.class, getReturnType().getType());
+        Type map = parameterizedType(null, Map.class, String.class, xor);
+        Type listType = parameterizedType(null, List.class, map);
         Type wrapperType = parameterizedType(null, Result.class, listType);
 
         @SuppressWarnings("unchecked")
-        Result<List<Map<String, R>>> wrapper = client.call(this, Client.LOCAL, "/",
+        Result<List<Map<String, Xor<SaltError, R>>>> wrapper = client.call(this, Client.LOCAL, "/",
                 Optional.of(customArgs),
-                (TypeToken<Result<List<Map<String, R>>>>) TypeToken.get(wrapperType));
+                (TypeToken<Result<List<Map<String, Xor<SaltError, R>>>>>) TypeToken.get(wrapperType));
         return wrapper.getResult().get(0);
     }
 
@@ -153,7 +155,7 @@ public class LocalCall<R> implements Call<R> {
      * @return a map containing the results with the minion name as key
      * @throws SaltException if anything goes wrong
      */
-    public Map<String, R> callSync(final SaltClient client, Target<?> target,
+    public Map<String, Xor<SaltError, R>> callSync(final SaltClient client, Target<?> target,
             String username, String password, AuthModule authModule)
             throws SaltException {
         Map<String, Object> customArgs = new HashMap<>();
@@ -164,15 +166,15 @@ public class LocalCall<R> implements Call<R> {
         customArgs.put("tgt", target.getTarget());
         customArgs.put("expr_form", target.getType());
 
-        Type mapType = parameterizedType(null, Map.class, String.class,
-                getReturnType().getType());
-        Type listType = parameterizedType(null, List.class, mapType);
+        Type xor = parameterizedType(null, Xor.class, SaltError.class, getReturnType().getType());
+        Type map = parameterizedType(null, Map.class, String.class, xor);
+        Type listType = parameterizedType(null, List.class, map);
         Type wrapperType = parameterizedType(null, Result.class, listType);
 
         @SuppressWarnings("unchecked")
-        Result<List<Map<String, R>>> wrapper = client.call(this, Client.LOCAL, "/run",
+        Result<List<Map<String, Xor<SaltError, R>>>> wrapper = client.call(this, Client.LOCAL, "/run",
                 Optional.of(customArgs),
-                (TypeToken<Result<List<Map<String, R>>>>) TypeToken.get(wrapperType));
+                (TypeToken<Result<List<Map<String, Xor<SaltError, R>>>>>) TypeToken.get(wrapperType));
         return wrapper.getResult().get(0);
     }
 }

--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -7,10 +7,9 @@ import com.suse.salt.netapi.client.SaltClient;
 import com.suse.salt.netapi.datatypes.target.Target;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.results.Result;
+import com.suse.salt.netapi.results.Return;
 
 import com.google.gson.reflect.TypeToken;
-import com.suse.salt.netapi.results.SaltError;
-import com.suse.salt.netapi.utils.Xor;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
@@ -72,10 +71,10 @@ public class LocalCall<R> implements Call<R> {
         customArgs.put("tgt", target.getTarget());
         customArgs.put("expr_form", target.getType());
 
-        Result<List<LocalAsyncResult<R>>> wrapper = client.call(
+        Return<List<LocalAsyncResult<R>>> wrapper = client.call(
                 this, Client.LOCAL_ASYNC, "/",
                 Optional.of(customArgs),
-                new TypeToken<Result<List<LocalAsyncResult<R>>>>(){});
+                new TypeToken<Return<List<LocalAsyncResult<R>>>>(){});
         LocalAsyncResult<R> result = wrapper.getResult().get(0);
         result.setType(getReturnType());
         return result;
@@ -105,10 +104,10 @@ public class LocalCall<R> implements Call<R> {
         customArgs.put("tgt", target.getTarget());
         customArgs.put("expr_form", target.getType());
 
-        Result<List<LocalAsyncResult<R>>> wrapper = client.call(
+        Return<List<LocalAsyncResult<R>>> wrapper = client.call(
                 this, Client.LOCAL_ASYNC, "/run",
                 Optional.of(customArgs),
-                new TypeToken<Result<List<LocalAsyncResult<R>>>>(){});
+                new TypeToken<Return<List<LocalAsyncResult<R>>>>(){});
         LocalAsyncResult<R> result = wrapper.getResult().get(0);
         result.setType(getReturnType());
         return result;
@@ -124,23 +123,22 @@ public class LocalCall<R> implements Call<R> {
      * @return a map containing the results with the minion name as key
      * @throws SaltException if anything goes wrong
      */
-    public Map<String, Xor<SaltError, R>> callSync(final SaltClient client,
-            Target<?> target) throws SaltException {
+    public Map<String, Result<R>> callSync(final SaltClient client,
+                                           Target<?> target) throws SaltException {
         Map<String, Object> customArgs = new HashMap<>();
         customArgs.put("tgt", target.getTarget());
         customArgs.put("expr_form", target.getType());
 
-        Type xor = parameterizedType(null, Xor.class, SaltError.class,
-                getReturnType().getType());
+        Type xor = parameterizedType(null, Result.class, getReturnType().getType());
         Type map = parameterizedType(null, Map.class, String.class, xor);
         Type listType = parameterizedType(null, List.class, map);
-        Type wrapperType = parameterizedType(null, Result.class, listType);
+        Type wrapperType = parameterizedType(null, Return.class, listType);
 
         @SuppressWarnings("unchecked")
-        Result<List<Map<String, Xor<SaltError, R>>>> wrapper = client.call(this,
+        Return<List<Map<String, Result<R>>>> wrapper = client.call(this,
                 Client.LOCAL, "/",
                 Optional.of(customArgs),
-                (TypeToken<Result<List<Map<String, Xor<SaltError, R>>>>>)
+                (TypeToken<Return<List<Map<String, Result<R>>>>>)
                 TypeToken.get(wrapperType));
         return wrapper.getResult().get(0);
     }
@@ -158,7 +156,7 @@ public class LocalCall<R> implements Call<R> {
      * @return a map containing the results with the minion name as key
      * @throws SaltException if anything goes wrong
      */
-    public Map<String, Xor<SaltError, R>> callSync(
+    public Map<String, Result<R>> callSync(
             final SaltClient client, Target<?> target,
             String username, String password, AuthModule authModule)
             throws SaltException {
@@ -170,17 +168,16 @@ public class LocalCall<R> implements Call<R> {
         customArgs.put("tgt", target.getTarget());
         customArgs.put("expr_form", target.getType());
 
-        Type xor = parameterizedType(null, Xor.class, SaltError.class,
-                getReturnType().getType());
+        Type xor = parameterizedType(null, Result.class, getReturnType().getType());
         Type map = parameterizedType(null, Map.class, String.class, xor);
         Type listType = parameterizedType(null, List.class, map);
-        Type wrapperType = parameterizedType(null, Result.class, listType);
+        Type wrapperType = parameterizedType(null, Return.class, listType);
 
         @SuppressWarnings("unchecked")
-        Result<List<Map<String, Xor<SaltError, R>>>> wrapper = client.call(this,
+        Return<List<Map<String, Result<R>>>> wrapper = client.call(this,
                 Client.LOCAL, "/run",
                 Optional.of(customArgs),
-                (TypeToken<Result<List<Map<String, Xor<SaltError, R>>>>>)
+                (TypeToken<Return<List<Map<String, Result<R>>>>>)
                 TypeToken.get(wrapperType));
         return wrapper.getResult().get(0);
     }

--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -124,21 +124,24 @@ public class LocalCall<R> implements Call<R> {
      * @return a map containing the results with the minion name as key
      * @throws SaltException if anything goes wrong
      */
-    public Map<String, Xor<SaltError, R>> callSync(final SaltClient client, Target<?> target)
-            throws SaltException {
+    public Map<String, Xor<SaltError, R>> callSync(final SaltClient client,
+            Target<?> target) throws SaltException {
         Map<String, Object> customArgs = new HashMap<>();
         customArgs.put("tgt", target.getTarget());
         customArgs.put("expr_form", target.getType());
 
-        Type xor = parameterizedType(null, Xor.class, SaltError.class, getReturnType().getType());
+        Type xor = parameterizedType(null, Xor.class, SaltError.class,
+                getReturnType().getType());
         Type map = parameterizedType(null, Map.class, String.class, xor);
         Type listType = parameterizedType(null, List.class, map);
         Type wrapperType = parameterizedType(null, Result.class, listType);
 
         @SuppressWarnings("unchecked")
-        Result<List<Map<String, Xor<SaltError, R>>>> wrapper = client.call(this, Client.LOCAL, "/",
+        Result<List<Map<String, Xor<SaltError, R>>>> wrapper = client.call(this,
+                Client.LOCAL, "/",
                 Optional.of(customArgs),
-                (TypeToken<Result<List<Map<String, Xor<SaltError, R>>>>>) TypeToken.get(wrapperType));
+                (TypeToken<Result<List<Map<String, Xor<SaltError, R>>>>>)
+                TypeToken.get(wrapperType));
         return wrapper.getResult().get(0);
     }
 
@@ -155,7 +158,8 @@ public class LocalCall<R> implements Call<R> {
      * @return a map containing the results with the minion name as key
      * @throws SaltException if anything goes wrong
      */
-    public Map<String, Xor<SaltError, R>> callSync(final SaltClient client, Target<?> target,
+    public Map<String, Xor<SaltError, R>> callSync(
+            final SaltClient client, Target<?> target,
             String username, String password, AuthModule authModule)
             throws SaltException {
         Map<String, Object> customArgs = new HashMap<>();
@@ -166,15 +170,18 @@ public class LocalCall<R> implements Call<R> {
         customArgs.put("tgt", target.getTarget());
         customArgs.put("expr_form", target.getType());
 
-        Type xor = parameterizedType(null, Xor.class, SaltError.class, getReturnType().getType());
+        Type xor = parameterizedType(null, Xor.class, SaltError.class,
+                getReturnType().getType());
         Type map = parameterizedType(null, Map.class, String.class, xor);
         Type listType = parameterizedType(null, List.class, map);
         Type wrapperType = parameterizedType(null, Result.class, listType);
 
         @SuppressWarnings("unchecked")
-        Result<List<Map<String, Xor<SaltError, R>>>> wrapper = client.call(this, Client.LOCAL, "/run",
+        Result<List<Map<String, Xor<SaltError, R>>>> wrapper = client.call(this,
+                Client.LOCAL, "/run",
                 Optional.of(customArgs),
-                (TypeToken<Result<List<Map<String, Xor<SaltError, R>>>>>) TypeToken.get(wrapperType));
+                (TypeToken<Result<List<Map<String, Xor<SaltError, R>>>>>)
+                TypeToken.get(wrapperType));
         return wrapper.getResult().get(0);
     }
 }

--- a/src/main/java/com/suse/salt/netapi/calls/RunnerCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/RunnerCall.java
@@ -5,7 +5,7 @@ import static com.suse.salt.netapi.utils.ClientUtils.parameterizedType;
 import com.suse.salt.netapi.AuthModule;
 import com.suse.salt.netapi.client.SaltClient;
 import com.suse.salt.netapi.exception.SaltException;
-import com.suse.salt.netapi.results.Result;
+import com.suse.salt.netapi.results.Return;
 
 import com.google.gson.reflect.TypeToken;
 
@@ -60,9 +60,9 @@ public class RunnerCall<R> implements Call<R> {
      */
     public RunnerAsyncResult<R> callAsync(final SaltClient client)
             throws SaltException {
-        Result<List<RunnerAsyncResult<R>>> wrapper = client.call(
+        Return<List<RunnerAsyncResult<R>>> wrapper = client.call(
                 this, Client.RUNNER_ASYNC, "/",
-                new TypeToken<Result<List<RunnerAsyncResult<R>>>>(){});
+                new TypeToken<Return<List<RunnerAsyncResult<R>>>>(){});
         RunnerAsyncResult<R> result = wrapper.getResult().get(0);
         result.setType(getReturnType());
         return result;
@@ -88,10 +88,10 @@ public class RunnerCall<R> implements Call<R> {
         customArgs.put("password", password);
         customArgs.put("eauth", authModule.getValue());
 
-        Result<List<RunnerAsyncResult<R>>> wrapper = client.call(
+        Return<List<RunnerAsyncResult<R>>> wrapper = client.call(
                 this, Client.RUNNER_ASYNC, "/run",
                 Optional.of(customArgs),
-                new TypeToken<Result<List<RunnerAsyncResult<R>>>>(){});
+                new TypeToken<Return<List<RunnerAsyncResult<R>>>>(){});
         RunnerAsyncResult<R> result = wrapper.getResult().get(0);
         result.setType(getReturnType());
         return result;
@@ -118,12 +118,12 @@ public class RunnerCall<R> implements Call<R> {
         customArgs.put("eauth", authModule.getValue());
 
         Type listType = parameterizedType(null, List.class, getReturnType().getType());
-        Type wrapperType = parameterizedType(null, Result.class, listType);
+        Type wrapperType = parameterizedType(null, Return.class, listType);
 
         @SuppressWarnings("unchecked")
-        Result<List<R>> wrapper = client.call(
+        Return<List<R>> wrapper = client.call(
                 this, Client.RUNNER, "/run", Optional.of(customArgs),
-                (TypeToken<Result<List<R>>>) TypeToken.get(wrapperType));
+                (TypeToken<Return<List<R>>>) TypeToken.get(wrapperType));
         return wrapper.getResult().get(0);
     }
 
@@ -138,11 +138,11 @@ public class RunnerCall<R> implements Call<R> {
      */
     public R callSync(final SaltClient client) throws SaltException {
         Type listType = parameterizedType(null, List.class, getReturnType().getType());
-        Type wrapperType = parameterizedType(null, Result.class, listType);
+        Type wrapperType = parameterizedType(null, Return.class, listType);
 
         @SuppressWarnings("unchecked")
-        Result<List<R>> wrapper = client.call(this, Client.RUNNER, "/",
-                (TypeToken<Result<List<R>>>) TypeToken.get(wrapperType));
+        Return<List<R>> wrapper = client.call(this, Client.RUNNER, "/",
+                (TypeToken<Return<List<R>>>) TypeToken.get(wrapperType));
         return wrapper.getResult().get(0);
     }
 

--- a/src/main/java/com/suse/salt/netapi/calls/WheelCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/WheelCall.java
@@ -5,7 +5,7 @@ import static com.suse.salt.netapi.utils.ClientUtils.parameterizedType;
 import com.suse.salt.netapi.AuthModule;
 import com.suse.salt.netapi.client.SaltClient;
 import com.suse.salt.netapi.exception.SaltException;
-import com.suse.salt.netapi.results.Result;
+import com.suse.salt.netapi.results.Return;
 
 import com.google.gson.reflect.TypeToken;
 
@@ -60,9 +60,9 @@ public class WheelCall<R> implements Call<R> {
      */
     public WheelAsyncResult<R> callAsync(final SaltClient client)
             throws SaltException {
-        Result<List<WheelAsyncResult<R>>> wrapper = client.call(
+        Return<List<WheelAsyncResult<R>>> wrapper = client.call(
                 this, Client.WHEEL_ASYNC, "/",
-                new TypeToken<Result<List<WheelAsyncResult<R>>>>(){});
+                new TypeToken<Return<List<WheelAsyncResult<R>>>>(){});
         WheelAsyncResult<R> result = wrapper.getResult().get(0);
         result.setType(getReturnType());
         return result;
@@ -88,10 +88,10 @@ public class WheelCall<R> implements Call<R> {
         customArgs.put("password", password);
         customArgs.put("eauth", authModule.getValue());
 
-        Result<List<WheelAsyncResult<R>>> wrapper = client.call(
+        Return<List<WheelAsyncResult<R>>> wrapper = client.call(
                 this, Client.WHEEL_ASYNC, "/run",
                 Optional.of(customArgs),
-                new TypeToken<Result<List<WheelAsyncResult<R>>>>(){});
+                new TypeToken<Return<List<WheelAsyncResult<R>>>>(){});
         WheelAsyncResult<R> result = wrapper.getResult().get(0);
         result.setType(getReturnType());
         return result;
@@ -111,11 +111,11 @@ public class WheelCall<R> implements Call<R> {
         Type wheelResult = parameterizedType(null, WheelResult.class,
                 getReturnType().getType());
         Type listType = parameterizedType(null, List.class, wheelResult);
-        Type wrapperType = parameterizedType(null, Result.class, listType);
+        Type wrapperType = parameterizedType(null, Return.class, listType);
 
         @SuppressWarnings("unchecked")
-        Result<List<WheelResult<R>>> wrapper = client.call(this, Client.WHEEL, "/",
-                (TypeToken<Result<List<WheelResult<R>>>>) TypeToken.get(wrapperType));
+        Return<List<WheelResult<R>>> wrapper = client.call(this, Client.WHEEL, "/",
+                (TypeToken<Return<List<WheelResult<R>>>>) TypeToken.get(wrapperType));
         return wrapper.getResult().get(0);
     }
 
@@ -143,12 +143,12 @@ public class WheelCall<R> implements Call<R> {
         Type wheelResult = parameterizedType(null, WheelResult.class,
                 getReturnType().getType());
         Type listType = parameterizedType(null, List.class, wheelResult);
-        Type wrapperType = parameterizedType(null, Result.class, listType);
+        Type wrapperType = parameterizedType(null, Return.class, listType);
 
         @SuppressWarnings("unchecked")
-        Result<List<WheelResult<R>>> wrapper = client.call(this, Client.WHEEL, "/run",
+        Return<List<WheelResult<R>>> wrapper = client.call(this, Client.WHEEL, "/run",
                 Optional.of(customArgs),
-                (TypeToken<Result<List<WheelResult<R>>>>) TypeToken.get(wrapperType));
+                (TypeToken<Return<List<WheelResult<R>>>>) TypeToken.get(wrapperType));
         return wrapper.getResult().get(0);
     }
 }

--- a/src/main/java/com/suse/salt/netapi/calls/modules/Test.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/Test.java
@@ -111,17 +111,17 @@ public class Test {
         private final Map<String, String> system;
 
         @SerializedName("Dependency Versions")
-        private final Map<String, String> dependencies;
+        private final Map<String, Optional<String>> dependencies;
 
         public VersionInformation(Map<String, String> salt,
                 Map<String, String> system,
-                Map<String, String> dependencies) {
+                Map<String, Optional<String>> dependencies) {
             this.salt = salt;
             this.system = system;
             this.dependencies = dependencies;
         }
 
-        public Map<String, String> getDependencies() {
+        public Map<String, Optional<String>> getDependencies() {
             return dependencies;
         }
 

--- a/src/main/java/com/suse/salt/netapi/calls/runner/Jobs.java
+++ b/src/main/java/com/suse/salt/netapi/calls/runner/Jobs.java
@@ -8,7 +8,7 @@ import com.suse.salt.netapi.calls.RunnerAsyncResult;
 import com.suse.salt.netapi.calls.RunnerCall;
 import com.suse.salt.netapi.calls.WheelAsyncResult;
 import com.suse.salt.netapi.datatypes.StartTime;
-import com.suse.salt.netapi.results.Result;
+import com.suse.salt.netapi.results.Return;
 
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
@@ -54,7 +54,7 @@ public class Jobs {
         private String target;
 
         @SerializedName("Result")
-        private Map<String, Result<R>> result;
+        private Map<String, Return<R>> result;
 
         public String getFunction() {
             return function;
@@ -88,14 +88,14 @@ public class Jobs {
             return target;
         }
 
-        public Map<String, Result<R>> getResult() {
+        public Map<String, Return<R>> getResult() {
             return result;
         }
 
         public Optional<R> resultOf(String minionKey) {
             return Optional.ofNullable(result).flatMap(
                 r -> Optional.ofNullable(r.get(minionKey))
-            ).map(Result::getResult);
+            ).map(Return::getResult);
         }
     }
 

--- a/src/main/java/com/suse/salt/netapi/client/SaltClient.java
+++ b/src/main/java/com/suse/salt/netapi/client/SaltClient.java
@@ -16,7 +16,7 @@ import com.suse.salt.netapi.event.EventListener;
 import com.suse.salt.netapi.event.EventStream;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.parser.JsonParser;
-import com.suse.salt.netapi.results.Result;
+import com.suse.salt.netapi.results.Return;
 import com.suse.salt.netapi.results.ResultInfoSet;
 
 import com.google.gson.Gson;
@@ -141,7 +141,7 @@ public class SaltClient {
 
         String payload = gson.toJson(props);
 
-        Result<List<Token>> result = connectionFactory
+        Return<List<Token>> result = connectionFactory
                 .create("/login", JsonParser.TOKEN, config)
                 .getResult(payload);
 
@@ -175,7 +175,7 @@ public class SaltClient {
      * @throws SaltException if anything goes wrong
      */
     public boolean logout() throws SaltException {
-        Result<String> stringResult = connectionFactory
+        Return<String> stringResult = connectionFactory
                 .create("/logout", JsonParser.STRING, config).getResult("");
         String logoutMessage = "Your token has been cleared";
         boolean result = logoutMessage.equals((stringResult.getResult()));
@@ -284,7 +284,7 @@ public class SaltClient {
         String payload = gson.toJson(Collections.singleton(props));
 
         // Connect to the minions endpoint and send the above lowstate data
-        Result<List<ScheduledJob>> result = connectionFactory
+        Return<List<ScheduledJob>> result = connectionFactory
                 .create("/minions", JsonParser.SCHEDULED_JOB,  config)
                 .getResult(payload);
 
@@ -348,7 +348,7 @@ public class SaltClient {
      * @throws SaltException if anything goes wrong
      */
     public Map<String, Job> getJobs() throws SaltException {
-        Result<List<Map<String, Job>>> result = connectionFactory
+        Return<List<Map<String, Job>>> result = connectionFactory
                 .create("/jobs", JsonParser.JOBS, config)
                 .getResult();
         return result.getResult().get(0);
@@ -401,7 +401,7 @@ public class SaltClient {
 
         String payload = gson.toJson(list);
 
-        Result<List<Map<String, Object>>> result = connectionFactory
+        Return<List<Map<String, Object>>> result = connectionFactory
                 .create("/run", JsonParser.RUN_RESULTS, config)
                 .getResult(payload);
 

--- a/src/main/java/com/suse/salt/netapi/datatypes/cherrypy/Request.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/cherrypy/Request.java
@@ -3,6 +3,7 @@ package com.suse.salt.netapi.datatypes.cherrypy;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.Date;
+import java.util.Optional;
 
 /**
  * Representation of request statistics.
@@ -10,19 +11,19 @@ import java.util.Date;
 public class Request {
 
     @SerializedName("Bytes Read")
-    private Integer bytesRead;
+    private Optional<Integer> bytesRead;
 
     @SerializedName("Bytes Written")
-    private Integer bytesWritten;
+    private Optional<Integer> bytesWritten;
 
     @SerializedName("Response Status")
-    private String responeStatus;
+    private Optional<String> responeStatus;
 
     @SerializedName("Start Time")
     private Date startTime;
 
     @SerializedName("End Time")
-    private Date endTime;
+    private Optional<Date> endTime;
 
     @SerializedName("Client")
     private String client;
@@ -33,15 +34,15 @@ public class Request {
     @SerializedName("Request-Line")
     private String requestLine;
 
-    public Integer getBytesRead() {
+    public Optional<Integer> getBytesRead() {
         return bytesRead;
     }
 
-    public Integer getBytesWritten() {
+    public Optional<Integer> getBytesWritten() {
         return bytesWritten;
     }
 
-    public String getResponeStatus() {
+    public Optional<String> getResponeStatus() {
         return responeStatus;
     }
 
@@ -49,7 +50,7 @@ public class Request {
         return startTime;
     }
 
-    public Date getEndTime() {
+    public Optional<Date> getEndTime() {
         return endTime;
     }
 

--- a/src/main/java/com/suse/salt/netapi/parser/Adapters.java
+++ b/src/main/java/com/suse/salt/netapi/parser/Adapters.java
@@ -3,13 +3,12 @@ package com.suse.salt.netapi.parser;
 import com.google.gson.JsonParseException;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
 
-class Adapters {
-    static final TypeAdapter<Boolean> BOOLEAN = new TypeAdapter<Boolean>() {
+public class Adapters {
+    public static final TypeAdapter<Boolean> BOOLEAN = new TypeAdapter<Boolean>() {
         @Override
         public Boolean read(JsonReader in) throws IOException {
             return in.nextBoolean();
@@ -24,7 +23,7 @@ class Adapters {
         }
     };
 
-    static final TypeAdapter<String> STRING = new TypeAdapter<String>() {
+    public static final TypeAdapter<String> STRING = new TypeAdapter<String>() {
         @Override
         public String read(JsonReader in) throws IOException {
             return in.nextString();

--- a/src/main/java/com/suse/salt/netapi/parser/Adapters.java
+++ b/src/main/java/com/suse/salt/netapi/parser/Adapters.java
@@ -1,0 +1,41 @@
+package com.suse.salt.netapi.parser;
+
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+class Adapters {
+    static final TypeAdapter<Boolean> BOOLEAN = new TypeAdapter<Boolean>() {
+        @Override
+        public Boolean read(JsonReader in) throws IOException {
+            return in.nextBoolean();
+        }
+        @Override
+        public void write(JsonWriter out, Boolean value) throws IOException {
+            if (value == null) {
+                throw new JsonParseException("null is not a valid value for boolean");
+            } else {
+                out.value(value);
+            }
+        }
+    };
+
+    static final TypeAdapter<String> STRING = new TypeAdapter<String>() {
+        @Override
+        public String read(JsonReader in) throws IOException {
+            return in.nextString();
+        }
+        @Override
+        public void write(JsonWriter out, String value) throws IOException {
+            if (value == null) {
+                throw new JsonParseException("null is not a valid value for string");
+            } else {
+                out.value(value);
+            }
+        }
+    };
+}

--- a/src/main/java/com/suse/salt/netapi/parser/Adapters.java
+++ b/src/main/java/com/suse/salt/netapi/parser/Adapters.java
@@ -8,6 +8,52 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 
 public class Adapters {
+
+    public static final TypeAdapter<Double> DOUBLE = new TypeAdapter<Double>() {
+        @Override
+        public Double read(JsonReader in) throws IOException {
+            return in.nextDouble();
+        }
+        @Override
+        public void write(JsonWriter out, Double value) throws IOException {
+            if (value == null) {
+                throw new JsonParseException("null is not a valid value for double");
+            } else {
+                out.value(value);
+            }
+        }
+    };
+
+    public static final TypeAdapter<Long> LONG = new TypeAdapter<Long>() {
+        @Override
+        public Long read(JsonReader in) throws IOException {
+            return in.nextLong();
+        }
+        @Override
+        public void write(JsonWriter out, Long value) throws IOException {
+            if (value == null) {
+                throw new JsonParseException("null is not a valid value for long");
+            } else {
+                out.value(value);
+            }
+        }
+    };
+
+    public static final TypeAdapter<Integer> INTEGER = new TypeAdapter<Integer>() {
+        @Override
+        public Integer read(JsonReader in) throws IOException {
+            return in.nextInt();
+        }
+        @Override
+        public void write(JsonWriter out, Integer value) throws IOException {
+            if (value == null) {
+                throw new JsonParseException("null is not a valid value for int");
+            } else {
+                out.value(value);
+            }
+        }
+    };
+
     public static final TypeAdapter<Boolean> BOOLEAN = new TypeAdapter<Boolean>() {
         @Override
         public Boolean read(JsonReader in) throws IOException {

--- a/src/main/java/com/suse/salt/netapi/parser/Adapters.java
+++ b/src/main/java/com/suse/salt/netapi/parser/Adapters.java
@@ -7,13 +7,18 @@ import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
 
+/**
+ * Strict null rejecting primitive type adapters.
+ */
 public class Adapters {
 
     public static final TypeAdapter<Double> DOUBLE = new TypeAdapter<Double>() {
+
         @Override
         public Double read(JsonReader in) throws IOException {
             return in.nextDouble();
         }
+
         @Override
         public void write(JsonWriter out, Double value) throws IOException {
             if (value == null) {
@@ -25,10 +30,12 @@ public class Adapters {
     };
 
     public static final TypeAdapter<Long> LONG = new TypeAdapter<Long>() {
+
         @Override
         public Long read(JsonReader in) throws IOException {
             return in.nextLong();
         }
+
         @Override
         public void write(JsonWriter out, Long value) throws IOException {
             if (value == null) {
@@ -40,10 +47,12 @@ public class Adapters {
     };
 
     public static final TypeAdapter<Integer> INTEGER = new TypeAdapter<Integer>() {
+
         @Override
         public Integer read(JsonReader in) throws IOException {
             return in.nextInt();
         }
+
         @Override
         public void write(JsonWriter out, Integer value) throws IOException {
             if (value == null) {
@@ -55,10 +64,12 @@ public class Adapters {
     };
 
     public static final TypeAdapter<Boolean> BOOLEAN = new TypeAdapter<Boolean>() {
+
         @Override
         public Boolean read(JsonReader in) throws IOException {
             return in.nextBoolean();
         }
+
         @Override
         public void write(JsonWriter out, Boolean value) throws IOException {
             if (value == null) {
@@ -70,10 +81,12 @@ public class Adapters {
     };
 
     public static final TypeAdapter<String> STRING = new TypeAdapter<String>() {
+
         @Override
         public String read(JsonReader in) throws IOException {
             return in.nextString();
         }
+
         @Override
         public void write(JsonWriter out, String value) throws IOException {
             if (value == null) {

--- a/src/main/java/com/suse/salt/netapi/parser/ArgumentsAdapter.java
+++ b/src/main/java/com/suse/salt/netapi/parser/ArgumentsAdapter.java
@@ -1,0 +1,82 @@
+package com.suse.salt.netapi.parser;
+
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import com.suse.salt.netapi.datatypes.Arguments;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Json TypeAdapter for Arguments class.
+ * Breaks the incoming arguments into args and kwargs parts
+ * and fills a new Arguments instance.
+ */
+public class ArgumentsAdapter extends TypeAdapter<Arguments> {
+
+    private static final String KWARG_KEY = "__kwarg__";
+
+    @Override
+    public void write(JsonWriter jsonWriter, Arguments args) throws IOException {
+        throw new UnsupportedOperationException("Writing JSON not supported.");
+    }
+
+    @Override
+    public Arguments read(JsonReader jsonReader) throws IOException {
+        if (jsonReader.peek() == JsonToken.NULL) {
+            throw new JsonParseException("null is not a valid value for Arguments");
+        }
+        Arguments result = new Arguments();
+        jsonReader.beginArray();
+        while (jsonReader.hasNext()) {
+            if (jsonReader.peek() == JsonToken.BEGIN_OBJECT) {
+                Map<String, Object> arg = readObjectArgument(jsonReader);
+                if (isKwarg(arg)) {
+                    arg.remove(KWARG_KEY);
+                    result.getKwargs().putAll(arg);
+                } else {
+                    result.getArgs().add(arg);
+                }
+            } else {
+                result.getArgs().add(JsonParser.GSON.fromJson(jsonReader, Object.class));
+            }
+        }
+        jsonReader.endArray();
+        return result;
+    }
+
+    /**
+     * Reads a generic object argument from the given JsonReader.
+     *
+     * @param jsonReader JsonReader expecting an object next
+     * @return Map representing a generic object argument
+     */
+    private Map<String, Object> readObjectArgument(JsonReader jsonReader)
+            throws IOException {
+        Map<String, Object> arg = new LinkedHashMap<>();
+        jsonReader.beginObject();
+        while (jsonReader.hasNext()) {
+            arg.put(jsonReader.nextName(), JsonParser.GSON.fromJson(jsonReader, Object.class));
+        }
+        jsonReader.endObject();
+        return arg;
+    }
+
+    /**
+     * Checks whether an object argument is kwarg.
+     * Object argument is kwarg if it contains __kwarg__ property set to true.
+     *
+     * @param arg object argument to be tested
+     * @return true if object argument is kwarg
+     */
+    private boolean isKwarg(Map<String, Object> arg) {
+        Object kwarg = arg.get(KWARG_KEY);
+        return kwarg != null
+                && kwarg instanceof Boolean
+                && ((Boolean) kwarg);
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/parser/ArgumentsAdapter.java
+++ b/src/main/java/com/suse/salt/netapi/parser/ArgumentsAdapter.java
@@ -60,7 +60,8 @@ public class ArgumentsAdapter extends TypeAdapter<Arguments> {
         Map<String, Object> arg = new LinkedHashMap<>();
         jsonReader.beginObject();
         while (jsonReader.hasNext()) {
-            arg.put(jsonReader.nextName(), JsonParser.GSON.fromJson(jsonReader, Object.class));
+            arg.put(jsonReader.nextName(),
+                    JsonParser.GSON.fromJson(jsonReader, Object.class));
         }
         jsonReader.endObject();
         return arg;

--- a/src/main/java/com/suse/salt/netapi/parser/DateAdapter.java
+++ b/src/main/java/com/suse/salt/netapi/parser/DateAdapter.java
@@ -1,0 +1,31 @@
+package com.suse.salt.netapi.parser;
+
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.util.Date;
+
+/**
+ * TypeAdapter for date representation received from the API
+ * (which represents it as a (floating) number of seconds since the Epoch).
+ */
+public class DateAdapter extends TypeAdapter<Date> {
+
+    @Override
+    public void write(JsonWriter jsonWriter, Date date) throws IOException {
+        throw new UnsupportedOperationException("Writing JSON not supported.");
+    }
+
+    @Override
+    public Date read(JsonReader jsonReader) throws IOException {
+        try {
+            double dateMilliseconds = jsonReader.nextDouble() * 1000;
+            return new Date((long) dateMilliseconds);
+        } catch (NumberFormatException | IllegalStateException e) {
+            throw new JsonParseException(e);
+        }
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/parser/JsonParser.java
+++ b/src/main/java/com/suse/salt/netapi/parser/JsonParser.java
@@ -7,36 +7,21 @@ import com.suse.salt.netapi.datatypes.Job;
 import com.suse.salt.netapi.datatypes.ScheduledJob;
 import com.suse.salt.netapi.datatypes.StartTime;
 import com.suse.salt.netapi.datatypes.Token;
-import com.suse.salt.netapi.datatypes.cherrypy.Applications;
-import com.suse.salt.netapi.datatypes.cherrypy.HttpServer;
 import com.suse.salt.netapi.datatypes.cherrypy.Stats;
-import com.suse.salt.netapi.results.Result;
-import com.suse.salt.netapi.results.ResultInfoSet;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapter;
-import com.google.gson.TypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonToken;
-import com.google.gson.stream.JsonWriter;
+import com.suse.salt.netapi.results.Result;
+import com.suse.salt.netapi.results.ResultInfoSet;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.lang.reflect.Type;
-import java.lang.reflect.ParameterizedType;
-import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
 import java.util.Date;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Parser for Salt API responses.
@@ -78,16 +63,18 @@ public class JsonParser<T> {
      * @param type A TypeToken describing the type this parser produces.
      */
     public JsonParser(TypeToken<T> type) {
+        this(type, GSON);
+    }
+
+    /**
+     * Created a new JsonParser for the given type.
+     *
+     * @param type A TypeToken describing the type this parser produces.
+     * @param gson Gson instance to use for parsing.
+     */
+    public JsonParser(TypeToken<T> type, Gson gson) {
         this.type = type;
-        this.gson = new GsonBuilder()
-                .registerTypeAdapter(Date.class, new DateAdapter().nullSafe())
-                .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeISOAdapter())
-                .registerTypeAdapter(ZonedDateTime.class, new ZonedDateTimeISOAdapter())
-                .registerTypeAdapter(StartTime.class, new StartTimeAdapter().nullSafe())
-                .registerTypeAdapter(Stats.class, new StatsAdapter())
-                .registerTypeAdapter(Arguments.class, new ArgumentsAdapter())
-                .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())
-                .create();
+        this.gson = gson;
     }
 
     /**
@@ -112,246 +99,5 @@ public class JsonParser<T> {
         return gson.fromJson(jsonString, type.getType());
     }
 
-    /**
-     * TypeAdapter for date representation received from the API
-     * (which represents it as a (floating) number of seconds since the Epoch).
-     */
-    private class DateAdapter extends TypeAdapter<Date> {
 
-        @Override
-        public void write(JsonWriter jsonWriter, Date date) throws IOException {
-            throw new UnsupportedOperationException("Writing JSON not supported.");
-        }
-
-        @Override
-        public Date read(JsonReader jsonReader) throws IOException {
-            try {
-                double dateMilliseconds = jsonReader.nextDouble() * 1000;
-                return new Date((long) dateMilliseconds);
-            } catch (NumberFormatException | IllegalStateException e) {
-                throw new JsonParseException(e);
-            }
-        }
-    }
-
-    /**
-     * TypeAdaptorFactory creating TypeAdapters for Optional
-     */
-    private class OptionalTypeAdapterFactory implements TypeAdapterFactory {
-
-        @Override
-        @SuppressWarnings("unchecked")
-        public <A> TypeAdapter<A> create(Gson gson, TypeToken<A> typeToken) {
-            Type type = typeToken.getType();
-            boolean isOptional = typeToken.getRawType() == Optional.class;
-            boolean isParameterized = type instanceof ParameterizedType;
-            if (isOptional && isParameterized) {
-                Type elementType = ((ParameterizedType) type).getActualTypeArguments()[0];
-                TypeAdapter<?> elementAdapter = gson.getAdapter(TypeToken.get(elementType));
-                return (TypeAdapter<A>) optionalAdapter(elementAdapter);
-            } else {
-                return null;
-            }
-        }
-
-        private <A> TypeAdapter<Optional<A>> optionalAdapter(TypeAdapter<A> innerAdapter) {
-            return new TypeAdapter<Optional<A>>() {
-                @Override
-                public Optional<A> read(JsonReader in) throws IOException {
-                    if (in.peek() == JsonToken.NULL) {
-                        in.nextNull();
-                        return Optional.empty();
-                    } else {
-                        A value = innerAdapter.read(in);
-                        return Optional.of(value);
-                    }
-                }
-
-                @Override
-                public void write(JsonWriter out, Optional<A> optional) throws IOException {
-                    innerAdapter.write(out, optional.orElse(null));
-                }
-            };
-        }
-    }
-
-    /**
-     * Json TypeAdapter for the Stats object received from the API.
-     */
-    private class StatsAdapter extends TypeAdapter<Stats> {
-
-        private static final String CP_APPLICATIONS = "CherryPy Applications";
-        private static final String CP_SERVER_PREFIX = "CherryPy HTTPServer ";
-
-        @Override
-        public void write(JsonWriter jsonWriter, Stats stats) throws IOException {
-            throw new UnsupportedOperationException("Writing JSON not supported.");
-        }
-
-        @Override
-        public Stats read(JsonReader jsonReader) throws IOException {
-            Applications app = null;
-            HttpServer server = null;
-            jsonReader.beginObject();
-            while (jsonReader.hasNext()) {
-                String name = jsonReader.nextName();
-                if (name.equals(CP_APPLICATIONS)) {
-                    app = gson.fromJson(jsonReader, Applications.class);
-                } else if (name.startsWith(CP_SERVER_PREFIX)) {
-                    server = gson.fromJson(jsonReader, HttpServer.class);
-                } else {
-                    jsonReader.skipValue();
-                }
-            }
-            jsonReader.endObject();
-            return new Stats(app, server);
-        }
-    }
-
-    /**
-     * Json TypeAdapter for Arguments class.
-     * Breaks the incoming arguments into args and kwargs parts
-     * and fills a new Arguments instance.
-     */
-    private class ArgumentsAdapter extends TypeAdapter<Arguments> {
-
-        private static final String KWARG_KEY = "__kwarg__";
-
-        @Override
-        public void write(JsonWriter jsonWriter, Arguments args) throws IOException {
-            throw new UnsupportedOperationException("Writing JSON not supported.");
-        }
-
-        @Override
-        public Arguments read(JsonReader jsonReader) throws IOException {
-            if (jsonReader.peek() == JsonToken.NULL) {
-                throw new JsonParseException("null is not a valid value for Arguments");
-            }
-            Arguments result = new Arguments();
-            jsonReader.beginArray();
-            while (jsonReader.hasNext()) {
-                if (jsonReader.peek() == JsonToken.BEGIN_OBJECT) {
-                    Map<String, Object> arg = readObjectArgument(jsonReader);
-                    if (isKwarg(arg)) {
-                        arg.remove(KWARG_KEY);
-                        result.getKwargs().putAll(arg);
-                    } else {
-                        result.getArgs().add(arg);
-                    }
-                } else {
-                    result.getArgs().add(gson.fromJson(jsonReader, Object.class));
-                }
-            }
-            jsonReader.endArray();
-            return result;
-        }
-
-        /**
-         * Reads a generic object argument from the given JsonReader.
-         *
-         * @param jsonReader JsonReader expecting an object next
-         * @return Map representing a generic object argument
-         */
-        private Map<String, Object> readObjectArgument(JsonReader jsonReader)
-                throws IOException {
-            Map<String, Object> arg = new LinkedHashMap<>();
-            jsonReader.beginObject();
-            while (jsonReader.hasNext()) {
-                arg.put(jsonReader.nextName(), gson.fromJson(jsonReader, Object.class));
-            }
-            jsonReader.endObject();
-            return arg;
-        }
-
-        /**
-         * Checks whether an object argument is kwarg.
-         * Object argument is kwarg if it contains __kwarg__ property set to true.
-         *
-         * @param arg object argument to be tested
-         * @return true if object argument is kwarg
-         */
-        private boolean isKwarg(Map<String, Object> arg) {
-            Object kwarg = arg.get(KWARG_KEY);
-            return kwarg != null
-                    && kwarg instanceof Boolean
-                    && ((Boolean) kwarg);
-        }
-    }
-
-    /**
-     * Json adapter to handle the Job.StartTime date format given by netapi
-     */
-    private class StartTimeAdapter extends TypeAdapter<StartTime> {
-
-        @Override
-        public void write(JsonWriter jsonWriter, StartTime date) throws IOException {
-            if (date == null) {
-                jsonWriter.nullValue();
-            } else {
-                jsonWriter.value(date.toString());
-            }
-        }
-
-        @Override
-        public StartTime read(JsonReader jsonReader) throws IOException {
-            if (jsonReader.peek() == JsonToken.NULL) {
-                jsonReader.nextNull();
-                return null;
-            }
-
-            String dateStr = jsonReader.nextString();
-            // Remove microseconds because java Date does not support it
-            String subStr = dateStr.substring(0, dateStr.length() - 3);
-            return new StartTime(subStr);
-        }
-    }
-
-
-    /**
-     * Adapter to convert an ISO formatted string to LocalDateTime
-     */
-    private class LocalDateTimeISOAdapter extends TypeAdapter<LocalDateTime> {
-
-        @Override
-        public void write(JsonWriter jsonWriter, LocalDateTime date) throws IOException {
-            if (date == null) {
-                throw new JsonParseException("null is not a valid value for LocalDateTime");
-            } else {
-                jsonWriter.value(date.toString());
-            }
-        }
-
-        @Override
-        public LocalDateTime read(JsonReader jsonReader) throws IOException {
-            if (jsonReader.peek() == JsonToken.NULL) {
-                throw new JsonParseException("null is not a valid value for LocalDateTime");
-            }
-            String dateStr = jsonReader.nextString();
-            return LocalDateTime.parse(dateStr);
-        }
-    }
-
-    /**
-     * Adapter to convert an ISO formatted string to ZonedDateTime
-     */
-    private class ZonedDateTimeISOAdapter extends TypeAdapter<ZonedDateTime> {
-
-        @Override
-        public void write(JsonWriter jsonWriter, ZonedDateTime date) throws IOException {
-            if (date == null) {
-                throw new JsonParseException("null is not a valid value for ZonedDateTime");
-            } else {
-                jsonWriter.value(date.toString());
-            }
-        }
-
-        @Override
-        public ZonedDateTime read(JsonReader jsonReader) throws IOException {
-            if (jsonReader.peek() == JsonToken.NULL) {
-                throw new JsonParseException("null is not a valid value for ZonedDateTime");
-            }
-            String dateStr = jsonReader.nextString();
-            return ZonedDateTime.parse(dateStr);
-        }
-    }
 }

--- a/src/main/java/com/suse/salt/netapi/parser/JsonParser.java
+++ b/src/main/java/com/suse/salt/netapi/parser/JsonParser.java
@@ -12,7 +12,7 @@ import com.suse.salt.netapi.datatypes.cherrypy.Stats;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
-import com.suse.salt.netapi.results.Result;
+import com.suse.salt.netapi.results.Return;
 import com.suse.salt.netapi.results.ResultInfoSet;
 
 import java.io.BufferedReader;
@@ -47,27 +47,28 @@ public class JsonParser<T> {
             .registerTypeAdapter(Arguments.class, new ArgumentsAdapter())
             .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())
             .registerTypeAdapterFactory(new XorTypeAdapterFactory())
+            .registerTypeAdapterFactory(new ResultTypeAdapterFactory())
             .create();
 
-    public static final JsonParser<Result<String>> STRING =
-            new JsonParser<>(new TypeToken<Result<String>>(){});
-    public static final JsonParser<Result<List<Token>>> TOKEN =
-            new JsonParser<>(new TypeToken<Result<List<Token>>>(){});
-    public static final JsonParser<Result<List<ScheduledJob>>> SCHEDULED_JOB =
-            new JsonParser<>(new TypeToken<Result<List<ScheduledJob>>>(){});
-    public static final JsonParser<Result<List<Map<String, Job>>>> JOBS =
-            new JsonParser<>(new TypeToken<Result<List<Map<String, Job>>>>(){});
+    public static final JsonParser<Return<String>> STRING =
+            new JsonParser<>(new TypeToken<Return<String>>(){});
+    public static final JsonParser<Return<List<Token>>> TOKEN =
+            new JsonParser<>(new TypeToken<Return<List<Token>>>(){});
+    public static final JsonParser<Return<List<ScheduledJob>>> SCHEDULED_JOB =
+            new JsonParser<>(new TypeToken<Return<List<ScheduledJob>>>(){});
+    public static final JsonParser<Return<List<Map<String, Job>>>> JOBS =
+            new JsonParser<>(new TypeToken<Return<List<Map<String, Job>>>>(){});
     public static final JsonParser<ResultInfoSet> JOB_RESULTS =
             new JsonParser<>(new TypeToken<ResultInfoSet>(){});
-    public static final JsonParser<Result<List<Map<String, Map<String, Object>>>>> RETMAPS =
+    public static final JsonParser<Return<List<Map<String, Map<String, Object>>>>> RETMAPS =
             new JsonParser<>(
-            new TypeToken<Result<List<Map<String, Map<String, Object>>>>>(){});
-    public static final JsonParser<Result<List<Map<String, Object>>>> RUN_RESULTS =
-            new JsonParser<>(new TypeToken<Result<List<Map<String, Object>>>>(){});
+            new TypeToken<Return<List<Map<String, Map<String, Object>>>>>(){});
+    public static final JsonParser<Return<List<Map<String, Object>>>> RUN_RESULTS =
+            new JsonParser<>(new TypeToken<Return<List<Map<String, Object>>>>(){});
     public static final JsonParser<Stats> STATS =
             new JsonParser<>(new TypeToken<Stats>(){});
-    public static final JsonParser<Result<Key.Names>> KEYS =
-            new JsonParser<>(new TypeToken<Result<Key.Names>>(){});
+    public static final JsonParser<Return<Key.Names>> KEYS =
+            new JsonParser<>(new TypeToken<Return<Key.Names>>(){});
     public static final JsonParser<Map<String, Object>> MAP =
             new JsonParser<>(new TypeToken<Map<String, Object>>(){});
     public static final JsonParser<Event> EVENTS =

--- a/src/main/java/com/suse/salt/netapi/parser/JsonParser.java
+++ b/src/main/java/com/suse/salt/netapi/parser/JsonParser.java
@@ -32,6 +32,23 @@ import java.util.Map;
  */
 public class JsonParser<T> {
 
+    public static final Gson GSON = new GsonBuilder()
+            // null rejecting strict variants for primitives
+            .registerTypeAdapter(String.class, Adapters.STRING)
+            .registerTypeAdapter(Boolean.class, Adapters.BOOLEAN)
+            .registerTypeAdapter(Integer.class, Adapters.INTEGER)
+            .registerTypeAdapter(Long.class, Adapters.LONG)
+            .registerTypeAdapter(Double.class, Adapters.DOUBLE)
+            .registerTypeAdapter(Date.class, new DateAdapter().nullSafe())
+            .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeISOAdapter())
+            .registerTypeAdapter(ZonedDateTime.class, new ZonedDateTimeISOAdapter())
+            .registerTypeAdapter(StartTime.class, new StartTimeAdapter().nullSafe())
+            .registerTypeAdapter(Stats.class, new StatsAdapter())
+            .registerTypeAdapter(Arguments.class, new ArgumentsAdapter())
+            .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())
+            .registerTypeAdapterFactory(new XorTypeAdapterFactory())
+            .create();
+
     public static final JsonParser<Result<String>> STRING =
             new JsonParser<>(new TypeToken<Result<String>>(){});
     public static final JsonParser<Result<List<Token>>> TOKEN =
@@ -58,18 +75,6 @@ public class JsonParser<T> {
 
     private final TypeToken<T> type;
     private final Gson gson;
-    public static final Gson GSON = new GsonBuilder()
-    .registerTypeAdapter(String.class, Adapters.STRING)
-    .registerTypeAdapter(Boolean.class, Adapters.BOOLEAN)
-    .registerTypeAdapter(Date.class, new DateAdapter().nullSafe())
-            .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeISOAdapter())
-            .registerTypeAdapter(ZonedDateTime.class, new ZonedDateTimeISOAdapter())
-            .registerTypeAdapter(StartTime.class, new StartTimeAdapter().nullSafe())
-            .registerTypeAdapter(Stats.class, new StatsAdapter())
-            .registerTypeAdapter(Arguments.class, new ArgumentsAdapter())
-            .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())
-            .registerTypeAdapterFactory(new XorTypeAdapterFactory())
-            .create();
 
     /**
      * Created a new JsonParser for the given type.

--- a/src/main/java/com/suse/salt/netapi/parser/JsonParser.java
+++ b/src/main/java/com/suse/salt/netapi/parser/JsonParser.java
@@ -19,6 +19,8 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -56,6 +58,18 @@ public class JsonParser<T> {
 
     private final TypeToken<T> type;
     private final Gson gson;
+    public static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(String.class, Adapters.STRING)
+    .registerTypeAdapter(Boolean.class, Adapters.BOOLEAN)
+    .registerTypeAdapter(Date.class, new DateAdapter().nullSafe())
+            .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeISOAdapter())
+            .registerTypeAdapter(ZonedDateTime.class, new ZonedDateTimeISOAdapter())
+            .registerTypeAdapter(StartTime.class, new StartTimeAdapter().nullSafe())
+            .registerTypeAdapter(Stats.class, new StatsAdapter())
+            .registerTypeAdapter(Arguments.class, new ArgumentsAdapter())
+            .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())
+            .registerTypeAdapterFactory(new XorTypeAdapterFactory())
+            .create();
 
     /**
      * Created a new JsonParser for the given type.

--- a/src/main/java/com/suse/salt/netapi/parser/LocalDateTimeISOAdapter.java
+++ b/src/main/java/com/suse/salt/netapi/parser/LocalDateTimeISOAdapter.java
@@ -1,0 +1,34 @@
+package com.suse.salt.netapi.parser;
+
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+/**
+ * Adapter to convert an ISO formatted string to LocalDateTime
+ */
+public class LocalDateTimeISOAdapter extends TypeAdapter<LocalDateTime> {
+
+    @Override
+    public void write(JsonWriter jsonWriter, LocalDateTime date) throws IOException {
+        if (date == null) {
+            throw new JsonParseException("null is not a valid value for LocalDateTime");
+        } else {
+            jsonWriter.value(date.toString());
+        }
+    }
+
+    @Override
+    public LocalDateTime read(JsonReader jsonReader) throws IOException {
+        if (jsonReader.peek() == JsonToken.NULL) {
+            throw new JsonParseException("null is not a valid value for LocalDateTime");
+        }
+        String dateStr = jsonReader.nextString();
+        return LocalDateTime.parse(dateStr);
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/parser/OptionalTypeAdapterFactory.java
+++ b/src/main/java/com/suse/salt/netapi/parser/OptionalTypeAdapterFactory.java
@@ -1,0 +1,55 @@
+package com.suse.salt.netapi.parser;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+/**
+ * TypeAdaptorFactory creating TypeAdapters for Optional
+ */
+public class OptionalTypeAdapterFactory implements TypeAdapterFactory {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <A> TypeAdapter<A> create(Gson gson, TypeToken<A> typeToken) {
+        Type type = typeToken.getType();
+        boolean isOptional = typeToken.getRawType() == Optional.class;
+        boolean isParameterized = type instanceof ParameterizedType;
+        if (isOptional && isParameterized) {
+            Type elementType = ((ParameterizedType) type).getActualTypeArguments()[0];
+            TypeAdapter<?> elementAdapter = gson.getAdapter(TypeToken.get(elementType));
+            return (TypeAdapter<A>) optionalAdapter(elementAdapter);
+        } else {
+            return null;
+        }
+    }
+
+    private <A> TypeAdapter<Optional<A>> optionalAdapter(TypeAdapter<A> innerAdapter) {
+        return new TypeAdapter<Optional<A>>() {
+            @Override
+            public Optional<A> read(JsonReader in) throws IOException {
+                if (in.peek() == JsonToken.NULL) {
+                    in.nextNull();
+                    return Optional.empty();
+                } else {
+                    A value = innerAdapter.read(in);
+                    return Optional.of(value);
+                }
+            }
+
+            @Override
+            public void write(JsonWriter out, Optional<A> optional) throws IOException {
+                innerAdapter.write(out, optional.orElse(null));
+            }
+        };
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/parser/ResultTypeAdapterFactory.java
+++ b/src/main/java/com/suse/salt/netapi/parser/ResultTypeAdapterFactory.java
@@ -16,6 +16,9 @@ import java.lang.reflect.Type;
 
 import static com.suse.salt.netapi.utils.ClientUtils.parameterizedType;
 
+/**
+ * {@link TypeAdapterFactory} for creating type adapters for parsing {@link Result} objects.
+ */
 public class ResultTypeAdapterFactory implements TypeAdapterFactory {
 
     @SuppressWarnings("unchecked")
@@ -26,7 +29,8 @@ public class ResultTypeAdapterFactory implements TypeAdapterFactory {
         if (isResult && isParameterized) {
             Type typeParam = ((ParameterizedType) type).getActualTypeArguments()[0];
             Type xorType = parameterizedType(null, Xor.class, SaltError.class, typeParam);
-            TypeAdapter<Xor> xorAdapter = (TypeAdapter<Xor>)gson.getAdapter(TypeToken.get(xorType));
+            TypeAdapter<Xor> xorAdapter = (TypeAdapter<Xor>) gson
+                    .getAdapter(TypeToken.get(xorType));
             return (TypeAdapter<A>) wrap(xorAdapter);
         } else {
             return null;
@@ -34,11 +38,11 @@ public class ResultTypeAdapterFactory implements TypeAdapterFactory {
     }
 
     @SuppressWarnings("unchecked")
-    private  TypeAdapter<Result> wrap(TypeAdapter<Xor> xorTypeAdapter) {
+    private TypeAdapter<Result> wrap(TypeAdapter<Xor> xorTypeAdapter) {
         return new TypeAdapter<Result>() {
             @Override
             public Result read(JsonReader in) throws IOException {
-               return new Result(xorTypeAdapter.read(in));
+                return new Result(xorTypeAdapter.read(in));
             }
 
             @Override

--- a/src/main/java/com/suse/salt/netapi/parser/ResultTypeAdapterFactory.java
+++ b/src/main/java/com/suse/salt/netapi/parser/ResultTypeAdapterFactory.java
@@ -21,7 +21,7 @@ import static com.suse.salt.netapi.utils.ClientUtils.parameterizedType;
  */
 public class ResultTypeAdapterFactory implements TypeAdapterFactory {
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public <A> TypeAdapter<A> create(Gson gson, TypeToken<A> typeToken) {
         Type type = typeToken.getType();
         boolean isResult = typeToken.getRawType() == Result.class;
@@ -37,7 +37,7 @@ public class ResultTypeAdapterFactory implements TypeAdapterFactory {
         }
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     private TypeAdapter<Result> wrap(TypeAdapter<Xor> xorTypeAdapter) {
         return new TypeAdapter<Result>() {
             @Override

--- a/src/main/java/com/suse/salt/netapi/parser/ResultTypeAdapterFactory.java
+++ b/src/main/java/com/suse/salt/netapi/parser/ResultTypeAdapterFactory.java
@@ -1,0 +1,50 @@
+package com.suse.salt.netapi.parser;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.suse.salt.netapi.results.Result;
+import com.suse.salt.netapi.results.SaltError;
+import com.suse.salt.netapi.utils.Xor;
+
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import static com.suse.salt.netapi.utils.ClientUtils.parameterizedType;
+
+public class ResultTypeAdapterFactory implements TypeAdapterFactory {
+
+    @SuppressWarnings("unchecked")
+    public <A> TypeAdapter<A> create(Gson gson, TypeToken<A> typeToken) {
+        Type type = typeToken.getType();
+        boolean isResult = typeToken.getRawType() == Result.class;
+        boolean isParameterized = type instanceof ParameterizedType;
+        if (isResult && isParameterized) {
+            Type typeParam = ((ParameterizedType) type).getActualTypeArguments()[0];
+            Type xorType = parameterizedType(null, Xor.class, SaltError.class, typeParam);
+            TypeAdapter<Xor> xorAdapter = (TypeAdapter<Xor>)gson.getAdapter(TypeToken.get(xorType));
+            return (TypeAdapter<A>) wrap(xorAdapter);
+        } else {
+            return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private  TypeAdapter<Result> wrap(TypeAdapter<Xor> xorTypeAdapter) {
+        return new TypeAdapter<Result>() {
+            @Override
+            public Result read(JsonReader in) throws IOException {
+               return new Result(xorTypeAdapter.read(in));
+            }
+
+            @Override
+            public void write(JsonWriter out, Result result) throws IOException {
+                xorTypeAdapter.write(out, result.toXor());
+            }
+        };
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/parser/StartTimeAdapter.java
+++ b/src/main/java/com/suse/salt/netapi/parser/StartTimeAdapter.java
@@ -1,0 +1,37 @@
+package com.suse.salt.netapi.parser;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import com.suse.salt.netapi.datatypes.StartTime;
+
+import java.io.IOException;
+
+/**
+ * Json adapter to handle the Job.StartTime date format given by netapi
+ */
+public class StartTimeAdapter extends TypeAdapter<StartTime> {
+
+    @Override
+    public void write(JsonWriter jsonWriter, StartTime date) throws IOException {
+        if (date == null) {
+            jsonWriter.nullValue();
+        } else {
+            jsonWriter.value(date.toString());
+        }
+    }
+
+    @Override
+    public StartTime read(JsonReader jsonReader) throws IOException {
+        if (jsonReader.peek() == JsonToken.NULL) {
+            jsonReader.nextNull();
+            return null;
+        }
+
+        String dateStr = jsonReader.nextString();
+        // Remove microseconds because java Date does not support it
+        String subStr = dateStr.substring(0, dateStr.length() - 3);
+        return new StartTime(subStr);
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/parser/StatsAdapter.java
+++ b/src/main/java/com/suse/salt/netapi/parser/StatsAdapter.java
@@ -1,0 +1,43 @@
+package com.suse.salt.netapi.parser;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.suse.salt.netapi.datatypes.cherrypy.Applications;
+import com.suse.salt.netapi.datatypes.cherrypy.HttpServer;
+import com.suse.salt.netapi.datatypes.cherrypy.Stats;
+
+import java.io.IOException;
+
+/**
+ * Json TypeAdapter for the Stats object received from the API.
+ */
+public class StatsAdapter extends TypeAdapter<Stats> {
+
+    private static final String CP_APPLICATIONS = "CherryPy Applications";
+    private static final String CP_SERVER_PREFIX = "CherryPy HTTPServer ";
+
+    @Override
+    public void write(JsonWriter jsonWriter, Stats stats) throws IOException {
+        throw new UnsupportedOperationException("Writing JSON not supported.");
+    }
+
+    @Override
+    public Stats read(JsonReader jsonReader) throws IOException {
+        Applications app = null;
+        HttpServer server = null;
+        jsonReader.beginObject();
+        while (jsonReader.hasNext()) {
+            String name = jsonReader.nextName();
+            if (name.equals(CP_APPLICATIONS)) {
+                app = JsonParser.GSON.fromJson(jsonReader, Applications.class);
+            } else if (name.startsWith(CP_SERVER_PREFIX)) {
+                server = JsonParser.GSON.fromJson(jsonReader, HttpServer.class);
+            } else {
+                jsonReader.skipValue();
+            }
+        }
+        jsonReader.endObject();
+        return new Stats(app, server);
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/parser/XorTypeAdapterFactory.java
+++ b/src/main/java/com/suse/salt/netapi/parser/XorTypeAdapterFactory.java
@@ -1,0 +1,87 @@
+package com.suse.salt.netapi.parser;
+
+import com.google.gson.*;
+import com.google.gson.internal.bind.TypeAdapters;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import com.suse.salt.netapi.results.*;
+import com.suse.salt.netapi.utils.Xor;
+
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * TypeAdaptorFactory creating TypeAdapters for Xor
+ */
+public class XorTypeAdapterFactory implements TypeAdapterFactory {
+
+    private Gson gson = new Gson();
+    private static final Pattern fnUnavailbale = Pattern.compile("'([^']+)' is not available.");
+    private static final Pattern moduleNotSupported = Pattern.compile("'([^']+)' __virtual__ returned False");
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <A> TypeAdapter<A> create(Gson gson, TypeToken<A> typeToken) {
+        Type type = typeToken.getType();
+        boolean isXor = typeToken.getRawType() == Xor.class;
+        boolean isParameterized = type instanceof ParameterizedType;
+        if (isXor && isParameterized){
+            Type rightType = ((ParameterizedType) type).getActualTypeArguments()[1];
+            TypeAdapter<?> elementAdapter = gson.getAdapter(TypeToken.get(rightType));
+            return (TypeAdapter<A>) errorAdapter(elementAdapter);
+        } else {
+            return null;
+        }
+    }
+
+
+    private <R> TypeAdapter<Xor<SaltError, R>> errorAdapter(TypeAdapter<R> innerAdapter) {
+        return new TypeAdapter<Xor<SaltError, R>>() {
+            @Override
+            public Xor<SaltError, R> read(JsonReader in) throws IOException {
+                JsonElement json = TypeAdapters.JSON_ELEMENT.read(in);
+                try {
+                    R value = innerAdapter.fromJsonTree(json);
+                    return Xor.right(value);
+                } catch (Throwable e) {
+                    if (json.isJsonPrimitive() && json.getAsJsonPrimitive().isString()) {
+                        String string = json.getAsJsonPrimitive().getAsString();
+                        Matcher fnUnvailableMatcher = fnUnavailbale.matcher(string);
+                        Matcher moduleNotSupportedMatcher = moduleNotSupported.matcher(string);
+                        if (fnUnvailableMatcher.find()) {
+                            String fn = fnUnvailableMatcher.group(1);
+                            return Xor.left(new FunctionNotAvailable(fn));
+                        } else if (moduleNotSupportedMatcher.find()) {
+                            String module = moduleNotSupportedMatcher.group(1);
+                            return Xor.left(new ModuleNotSupported(module));
+                        } else {
+                            List<String> strings = Arrays.asList(string.split("\n"));
+                            if (strings.size() > 0) {
+                               if (strings.get(0).contentEquals("The minion function caused an exception: Traceback (most recent call last):")) {
+                                   String stacktrace = strings.stream().skip(1).collect(Collectors.joining("\n"));
+                                   return Xor.left(new StackTraceError(stacktrace));
+                               }
+                            }
+                            return Xor.left(new GenericSaltError(json));
+                        }
+                    } else {
+                        return Xor.left(new GenericSaltError(json));
+                    }
+                }
+            }
+
+            @Override
+            public void write(JsonWriter out, Xor<SaltError, R> xor) throws IOException {
+                throw new JsonParseException("Writing Xor is not supported");
+            }
+        };
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/parser/XorTypeAdapterFactory.java
+++ b/src/main/java/com/suse/salt/netapi/parser/XorTypeAdapterFactory.java
@@ -1,12 +1,19 @@
 package com.suse.salt.netapi.parser;
 
-import com.google.gson.*;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
 import com.google.gson.internal.bind.TypeAdapters;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
-import com.suse.salt.netapi.results.*;
+import com.suse.salt.netapi.results.FunctionNotAvailable;
+import com.suse.salt.netapi.results.GenericSaltError;
+import com.suse.salt.netapi.results.ModuleNotSupported;
+import com.suse.salt.netapi.results.SaltError;
+import com.suse.salt.netapi.results.StackTraceError;
 import com.suse.salt.netapi.utils.Xor;
 
 import java.io.IOException;
@@ -23,9 +30,10 @@ import java.util.stream.Collectors;
  */
 public class XorTypeAdapterFactory implements TypeAdapterFactory {
 
-    private Gson gson = new Gson();
-    private static final Pattern fnUnavailbale = Pattern.compile("'([^']+)' is not available.");
-    private static final Pattern moduleNotSupported = Pattern.compile("'([^']+)' __virtual__ returned False");
+    private static final Pattern FN_UNAVAILABLE =
+            Pattern.compile("'([^']+)' is not available.");
+    private static final Pattern MODULE_NOT_SUPPORTED =
+            Pattern.compile("'([^']+)' __virtual__ returned False");
 
     @Override
     @SuppressWarnings("unchecked")
@@ -33,7 +41,7 @@ public class XorTypeAdapterFactory implements TypeAdapterFactory {
         Type type = typeToken.getType();
         boolean isXor = typeToken.getRawType() == Xor.class;
         boolean isParameterized = type instanceof ParameterizedType;
-        if (isXor && isParameterized){
+        if (isXor && isParameterized) {
             Type rightType = ((ParameterizedType) type).getActualTypeArguments()[1];
             TypeAdapter<?> elementAdapter = gson.getAdapter(TypeToken.get(rightType));
             return (TypeAdapter<A>) errorAdapter(elementAdapter);
@@ -41,7 +49,6 @@ public class XorTypeAdapterFactory implements TypeAdapterFactory {
             return null;
         }
     }
-
 
     private <R> TypeAdapter<Xor<SaltError, R>> errorAdapter(TypeAdapter<R> innerAdapter) {
         return new TypeAdapter<Xor<SaltError, R>>() {
@@ -54,21 +61,24 @@ public class XorTypeAdapterFactory implements TypeAdapterFactory {
                 } catch (Throwable e) {
                     if (json.isJsonPrimitive() && json.getAsJsonPrimitive().isString()) {
                         String string = json.getAsJsonPrimitive().getAsString();
-                        Matcher fnUnvailableMatcher = fnUnavailbale.matcher(string);
-                        Matcher moduleNotSupportedMatcher = moduleNotSupported.matcher(string);
-                        if (fnUnvailableMatcher.find()) {
-                            String fn = fnUnvailableMatcher.group(1);
+                        Matcher fnuMatcher = FN_UNAVAILABLE.matcher(string);
+                        Matcher mnsMatcher = MODULE_NOT_SUPPORTED.matcher(string);
+                        if (fnuMatcher.find()) {
+                            String fn = fnuMatcher.group(1);
                             return Xor.left(new FunctionNotAvailable(fn));
-                        } else if (moduleNotSupportedMatcher.find()) {
-                            String module = moduleNotSupportedMatcher.group(1);
+                        } else if (mnsMatcher.find()) {
+                            String module = mnsMatcher.group(1);
                             return Xor.left(new ModuleNotSupported(module));
                         } else {
                             List<String> strings = Arrays.asList(string.split("\n"));
                             if (strings.size() > 0) {
-                               if (strings.get(0).contentEquals("The minion function caused an exception: Traceback (most recent call last):")) {
-                                   String stacktrace = strings.stream().skip(1).collect(Collectors.joining("\n"));
-                                   return Xor.left(new StackTraceError(stacktrace));
-                               }
+                                if (strings.get(0).contentEquals("The minion function" +
+                                        " caused an exception: Traceback (most recent" +
+                                        " call last):")) {
+                                    String stacktrace = strings.stream().skip(1)
+                                            .collect(Collectors.joining("\n"));
+                                    return Xor.left(new StackTraceError(stacktrace));
+                                }
                             }
                             return Xor.left(new GenericSaltError(json));
                         }

--- a/src/main/java/com/suse/salt/netapi/parser/ZonedDateTimeISOAdapter.java
+++ b/src/main/java/com/suse/salt/netapi/parser/ZonedDateTimeISOAdapter.java
@@ -1,0 +1,34 @@
+package com.suse.salt.netapi.parser;
+
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+
+/**
+ * Adapter to convert an ISO formatted string to ZonedDateTime
+ */
+public class ZonedDateTimeISOAdapter extends TypeAdapter<ZonedDateTime> {
+
+    @Override
+    public void write(JsonWriter jsonWriter, ZonedDateTime date) throws IOException {
+        if (date == null) {
+            throw new JsonParseException("null is not a valid value for ZonedDateTime");
+        } else {
+            jsonWriter.value(date.toString());
+        }
+    }
+
+    @Override
+    public ZonedDateTime read(JsonReader jsonReader) throws IOException {
+        if (jsonReader.peek() == JsonToken.NULL) {
+            throw new JsonParseException("null is not a valid value for ZonedDateTime");
+        }
+        String dateStr = jsonReader.nextString();
+        return ZonedDateTime.parse(dateStr);
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/results/FunctionNotAvailable.java
+++ b/src/main/java/com/suse/salt/netapi/results/FunctionNotAvailable.java
@@ -3,7 +3,7 @@ package com.suse.salt.netapi.results;
 /**
  * Salt error when trying to execute a function that does not exist
  */
-public class FunctionNotAvailable implements SaltError {
+final public class FunctionNotAvailable implements SaltError {
 
    private final String functionName;
 
@@ -18,5 +18,22 @@ public class FunctionNotAvailable implements SaltError {
    @Override
    public String toString() {
       return "FunctionNotAvailable(" + functionName + ")";
+   }
+
+   @Override
+   public int hashCode() {
+      return toString().hashCode();
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
+      } else if (obj == null) {
+         return false;
+      } else {
+         return obj instanceof FunctionNotAvailable &&
+                 ((FunctionNotAvailable) obj).getFunctionName().contentEquals(getFunctionName());
+      }
    }
 }

--- a/src/main/java/com/suse/salt/netapi/results/FunctionNotAvailable.java
+++ b/src/main/java/com/suse/salt/netapi/results/FunctionNotAvailable.java
@@ -5,35 +5,36 @@ package com.suse.salt.netapi.results;
  */
 final public class FunctionNotAvailable implements SaltError {
 
-   private final String functionName;
+    private final String functionName;
 
-   public FunctionNotAvailable(String fn) {
-      this.functionName = fn;
-   }
+    public FunctionNotAvailable(String fn) {
+        this.functionName = fn;
+    }
 
-   public String getFunctionName() {
-      return functionName;
-   }
+    public String getFunctionName() {
+        return functionName;
+    }
 
-   @Override
-   public String toString() {
-      return "FunctionNotAvailable(" + functionName + ")";
-   }
+    @Override
+    public String toString() {
+        return "FunctionNotAvailable(" + functionName + ")";
+    }
 
-   @Override
-   public int hashCode() {
-      return toString().hashCode();
-   }
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
 
-   @Override
-   public boolean equals(Object obj) {
-      if (this == obj) {
-         return true;
-      } else if (obj == null) {
-         return false;
-      } else {
-         return obj instanceof FunctionNotAvailable &&
-                 ((FunctionNotAvailable) obj).getFunctionName().contentEquals(getFunctionName());
-      }
-   }
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null) {
+            return false;
+        } else {
+            return obj instanceof FunctionNotAvailable &&
+                   ((FunctionNotAvailable) obj).getFunctionName()
+                         .contentEquals(getFunctionName());
+        }
+    }
 }

--- a/src/main/java/com/suse/salt/netapi/results/FunctionNotAvailable.java
+++ b/src/main/java/com/suse/salt/netapi/results/FunctionNotAvailable.java
@@ -1,0 +1,22 @@
+package com.suse.salt.netapi.results;
+
+/**
+ * Salt error when trying to execute a function that does not exist
+ */
+public class FunctionNotAvailable implements SaltError {
+
+   private final String functionName;
+
+   public FunctionNotAvailable(String fn) {
+      this.functionName = fn;
+   }
+
+   public String getFunctionName() {
+      return functionName;
+   }
+
+   @Override
+   public String toString() {
+      return "FunctionNotAvailable(" + functionName + ")";
+   }
+}

--- a/src/main/java/com/suse/salt/netapi/results/GenericSaltError.java
+++ b/src/main/java/com/suse/salt/netapi/results/GenericSaltError.java
@@ -10,7 +10,7 @@ final public class GenericSaltError implements SaltError {
     private final JsonElement json;
 
     public GenericSaltError(JsonElement json) {
-       this.json = json;
+        this.json = json;
     }
 
     @Override

--- a/src/main/java/com/suse/salt/netapi/results/GenericSaltError.java
+++ b/src/main/java/com/suse/salt/netapi/results/GenericSaltError.java
@@ -1,0 +1,20 @@
+package com.suse.salt.netapi.results;
+
+import com.google.gson.JsonElement;
+
+/**
+ * Catch all error that contains the rest of the json which could not be parsed.
+ */
+public class GenericSaltError implements SaltError {
+
+    private final JsonElement json;
+
+    public GenericSaltError(JsonElement json) {
+       this.json = json;
+    }
+
+    @Override
+    public String toString() {
+        return "GenericSaltError(" + json.toString() + ")";
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/results/GenericSaltError.java
+++ b/src/main/java/com/suse/salt/netapi/results/GenericSaltError.java
@@ -5,7 +5,7 @@ import com.google.gson.JsonElement;
 /**
  * Catch all error that contains the rest of the json which could not be parsed.
  */
-public class GenericSaltError implements SaltError {
+final public class GenericSaltError implements SaltError {
 
     private final JsonElement json;
 
@@ -16,5 +16,22 @@ public class GenericSaltError implements SaltError {
     @Override
     public String toString() {
         return "GenericSaltError(" + json.toString() + ")";
+    }
+
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null) {
+            return false;
+        } else {
+            return obj instanceof GenericSaltError &&
+                    ((GenericSaltError) obj).json.equals(json);
+        }
     }
 }

--- a/src/main/java/com/suse/salt/netapi/results/ModuleNotSupported.java
+++ b/src/main/java/com/suse/salt/netapi/results/ModuleNotSupported.java
@@ -1,0 +1,19 @@
+package com.suse.salt.netapi.results;
+
+public class ModuleNotSupported implements SaltError {
+
+   private final String moduleName;
+
+   public ModuleNotSupported(String module) {
+      this.moduleName = module;
+   }
+
+   public String getModuleName() {
+      return moduleName;
+   }
+
+   @Override
+   public String toString() {
+      return "ModuleNotSupported(" + moduleName + ")";
+   }
+}

--- a/src/main/java/com/suse/salt/netapi/results/ModuleNotSupported.java
+++ b/src/main/java/com/suse/salt/netapi/results/ModuleNotSupported.java
@@ -1,6 +1,6 @@
 package com.suse.salt.netapi.results;
 
-public class ModuleNotSupported implements SaltError {
+final public class ModuleNotSupported implements SaltError {
 
    private final String moduleName;
 
@@ -15,5 +15,22 @@ public class ModuleNotSupported implements SaltError {
    @Override
    public String toString() {
       return "ModuleNotSupported(" + moduleName + ")";
+   }
+
+   @Override
+   public int hashCode() {
+      return toString().hashCode();
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
+      } else if (obj == null) {
+         return false;
+      } else {
+         return obj instanceof ModuleNotSupported &&
+                 ((ModuleNotSupported) obj).getModuleName().contentEquals(getModuleName());
+      }
    }
 }

--- a/src/main/java/com/suse/salt/netapi/results/ModuleNotSupported.java
+++ b/src/main/java/com/suse/salt/netapi/results/ModuleNotSupported.java
@@ -1,36 +1,39 @@
 package com.suse.salt.netapi.results;
 
+/**
+ * Error that happens if a modules is not supported
+ */
 final public class ModuleNotSupported implements SaltError {
 
-   private final String moduleName;
+    private final String moduleName;
 
-   public ModuleNotSupported(String module) {
-      this.moduleName = module;
-   }
+    public ModuleNotSupported(String module) {
+        this.moduleName = module;
+    }
 
-   public String getModuleName() {
-      return moduleName;
-   }
+    public String getModuleName() {
+        return moduleName;
+    }
 
-   @Override
-   public String toString() {
-      return "ModuleNotSupported(" + moduleName + ")";
-   }
+    @Override
+    public String toString() {
+        return "ModuleNotSupported(" + moduleName + ")";
+    }
 
-   @Override
-   public int hashCode() {
-      return toString().hashCode();
-   }
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
 
-   @Override
-   public boolean equals(Object obj) {
-      if (this == obj) {
-         return true;
-      } else if (obj == null) {
-         return false;
-      } else {
-         return obj instanceof ModuleNotSupported &&
-                 ((ModuleNotSupported) obj).getModuleName().contentEquals(getModuleName());
-      }
-   }
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null) {
+            return false;
+        } else {
+            return obj instanceof ModuleNotSupported &&
+                  ((ModuleNotSupported) obj).getModuleName().contentEquals(getModuleName());
+        }
+    }
 }

--- a/src/main/java/com/suse/salt/netapi/results/Result.java
+++ b/src/main/java/com/suse/salt/netapi/results/Result.java
@@ -42,6 +42,8 @@ public class Result<R> {
         return new Result<>(xor.map(mapper));
     }
 
+    // FIXME: Redundant definition of type arguments needed for oraclejdk8
+    @SuppressWarnings("unused")
     public <T> Result<T> flatMap(Function<? super R, Result<T>> mapper) {
         return xor.fold(
             e -> new Result<T>(Xor.left(e)),

--- a/src/main/java/com/suse/salt/netapi/results/Result.java
+++ b/src/main/java/com/suse/salt/netapi/results/Result.java
@@ -44,7 +44,7 @@ public class Result<R> {
 
     public <T> Result<T> flatMap(Function<? super R, Result<T>> mapper) {
         return xor.fold(
-            e -> new Result<>(Xor.left(e)),
+            e -> new Result<T>(Xor.left(e)),
             mapper
         );
     }

--- a/src/main/java/com/suse/salt/netapi/results/Result.java
+++ b/src/main/java/com/suse/salt/netapi/results/Result.java
@@ -1,23 +1,48 @@
 package com.suse.salt.netapi.results;
 
-import com.google.gson.annotations.SerializedName;
+import com.suse.salt.netapi.utils.Xor;
 
-/**
- * Represents a Salt API result.
- *
- * @param <T> The type of the value this result holds.
- */
-public class Result<T> {
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
-    @SerializedName("return")
-    private T result;
+public class Result<R> {
+    private final Xor<SaltError, R> xor;
 
-    /**
-     * Returns the value of this result.
-     *
-     * @return The value of this result.
-     */
-    public T getResult() {
-        return result;
+    public Result(Xor<SaltError, R> xor) {
+        this.xor = xor;
+    }
+
+    public Optional<SaltError> error() {
+        return xor.left();
+    }
+
+    public Optional<R> result() {
+        return xor.right();
+    }
+
+    public <T> T fold(Function<? super SaltError, ? extends T> mapError,
+                      Function<? super R, ? extends T> mapResult) {
+        return xor.fold(mapError, mapResult);
+    }
+
+    public void consume(Consumer<? super SaltError> consumerError,
+                     Consumer<? super R> consumerResult) {
+        xor.consume(consumerError, consumerResult);
+    }
+
+    public <T> Result<T> map(Function<? super R, ? extends T> mapper) {
+        return new Result<>(xor.map(mapper));
+    }
+
+    public <T> Result<T> flatMap(Function<? super R, Result<T>> mapper) {
+        return xor.fold(
+            e -> new Result<>(Xor.left(e)),
+            mapper
+        );
+    }
+
+    public Xor<SaltError, R> toXor() {
+        return xor;
     }
 }

--- a/src/main/java/com/suse/salt/netapi/results/Result.java
+++ b/src/main/java/com/suse/salt/netapi/results/Result.java
@@ -54,4 +54,25 @@ public class Result<R> {
     public Xor<SaltError, R> toXor() {
         return xor;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        Result<?> other = (Result<?>) obj;
+        return xor.equals(other.xor);
+    }
+
+    @Override
+    public String toString() {
+        return xor.fold(
+            error -> "Error(" + error + ")",
+            result -> "Result(" + result + ")"
+        );
+    }
 }

--- a/src/main/java/com/suse/salt/netapi/results/Result.java
+++ b/src/main/java/com/suse/salt/netapi/results/Result.java
@@ -6,7 +6,14 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+/**
+ * Representation of call results for a single minion implemented as a wrapper around
+ * {@link Xor}.
+ *
+ * @param <R> the type of the internal result
+ */
 public class Result<R> {
+
     private final Xor<SaltError, R> xor;
 
     public Result(Xor<SaltError, R> xor) {
@@ -22,12 +29,12 @@ public class Result<R> {
     }
 
     public <T> T fold(Function<? super SaltError, ? extends T> mapError,
-                      Function<? super R, ? extends T> mapResult) {
+            Function<? super R, ? extends T> mapResult) {
         return xor.fold(mapError, mapResult);
     }
 
     public void consume(Consumer<? super SaltError> consumerError,
-                     Consumer<? super R> consumerResult) {
+            Consumer<? super R> consumerResult) {
         xor.consume(consumerError, consumerResult);
     }
 

--- a/src/main/java/com/suse/salt/netapi/results/ResultInfo.java
+++ b/src/main/java/com/suse/salt/netapi/results/ResultInfo.java
@@ -37,7 +37,7 @@ public class ResultInfo {
     private String target;
 
     @SerializedName("Result")
-    private HashMap<String, Result<Object>> rawResults;
+    private HashMap<String, Return<Object>> rawResults;
     private transient final HashMap<String, Object> resultsCache = new HashMap<>();
 
     /**
@@ -113,7 +113,7 @@ public class ResultInfo {
      * @return {@link Optional} associated with the result from a given minion.
      */
     public Optional<Object> getResult(String minion) {
-        Result<Object> result;
+        Return<Object> result;
         if (rawResults == null || (result = rawResults.get(minion)) == null) {
             return Optional.<Object>empty();
         }
@@ -136,7 +136,7 @@ public class ResultInfo {
         resultsCache.clear();
         resultsCache.putAll(rawResults);
         resultsCache.replaceAll(
-                (String key, Object result) -> ((Result<Object>) result).getResult());
+                (String key, Object result) -> ((Return<Object>) result).getResult());
         return resultsCache;
     }
 

--- a/src/main/java/com/suse/salt/netapi/results/Return.java
+++ b/src/main/java/com/suse/salt/netapi/results/Return.java
@@ -1,0 +1,23 @@
+package com.suse.salt.netapi.results;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Represents a Salt API result.
+ *
+ * @param <T> The type of the value this result holds.
+ */
+public class Return<T> {
+
+    @SerializedName("return")
+    private T result;
+
+    /**
+     * Returns the value of this result.
+     *
+     * @return The value of this result.
+     */
+    public T getResult() {
+        return result;
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/results/SaltError.java
+++ b/src/main/java/com/suse/salt/netapi/results/SaltError.java
@@ -1,0 +1,8 @@
+package com.suse.salt.netapi.results;
+
+/**
+ * Interface for all salt related errors
+ */
+public interface SaltError {
+}
+

--- a/src/main/java/com/suse/salt/netapi/results/StackTraceError.java
+++ b/src/main/java/com/suse/salt/netapi/results/StackTraceError.java
@@ -5,35 +5,35 @@ package com.suse.salt.netapi.results;
  */
 final public class StackTraceError implements SaltError {
 
-   private final String stacktrace;
+    private final String stacktrace;
 
-   public StackTraceError(String fn) {
-      this.stacktrace = fn;
-   }
+    public StackTraceError(String fn) {
+        this.stacktrace = fn;
+    }
 
-   public String getStacktrace() {
-      return stacktrace;
-   }
+    public String getStacktrace() {
+        return stacktrace;
+    }
 
-   @Override
-   public String toString() {
-      return "StackTraceError(" + stacktrace + ")";
-   }
+    @Override
+    public String toString() {
+        return "StackTraceError(" + stacktrace + ")";
+    }
 
-   @Override
-   public int hashCode() {
-      return toString().hashCode();
-   }
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
 
-   @Override
-   public boolean equals(Object obj) {
-      if (this == obj) {
-         return true;
-      } else if (obj == null) {
-         return false;
-      } else {
-         return obj instanceof StackTraceError &&
-                 ((StackTraceError) obj).getStacktrace().contentEquals(getStacktrace());
-      }
-   }
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null) {
+            return false;
+        } else {
+            return obj instanceof StackTraceError &&
+                    ((StackTraceError) obj).getStacktrace().contentEquals(getStacktrace());
+        }
+    }
 }

--- a/src/main/java/com/suse/salt/netapi/results/StackTraceError.java
+++ b/src/main/java/com/suse/salt/netapi/results/StackTraceError.java
@@ -3,7 +3,7 @@ package com.suse.salt.netapi.results;
 /**
  * Salt error containing a stacktrace if one is returned instead of a result
  */
-public class StackTraceError implements SaltError {
+final public class StackTraceError implements SaltError {
 
    private final String stacktrace;
 
@@ -18,5 +18,22 @@ public class StackTraceError implements SaltError {
    @Override
    public String toString() {
       return "StackTraceError(" + stacktrace + ")";
+   }
+
+   @Override
+   public int hashCode() {
+      return toString().hashCode();
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
+      } else if (obj == null) {
+         return false;
+      } else {
+         return obj instanceof StackTraceError &&
+                 ((StackTraceError) obj).getStacktrace().contentEquals(getStacktrace());
+      }
    }
 }

--- a/src/main/java/com/suse/salt/netapi/results/StackTraceError.java
+++ b/src/main/java/com/suse/salt/netapi/results/StackTraceError.java
@@ -1,0 +1,22 @@
+package com.suse.salt.netapi.results;
+
+/**
+ * Salt error containing a stacktrace if one is returned instead of a result
+ */
+public class StackTraceError implements SaltError {
+
+   private final String stacktrace;
+
+   public StackTraceError(String fn) {
+      this.stacktrace = fn;
+   }
+
+   public String getStacktrace() {
+      return stacktrace;
+   }
+
+   @Override
+   public String toString() {
+      return "StackTraceError(" + stacktrace + ")";
+   }
+}

--- a/src/main/java/com/suse/salt/netapi/utils/Xor.java
+++ b/src/main/java/com/suse/salt/netapi/utils/Xor.java
@@ -2,6 +2,7 @@ package com.suse.salt.netapi.utils;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -29,6 +30,9 @@ public abstract class Xor<L, R> {
 
     public abstract <T> T fold(Function<? super L, ? extends T> mapLeft,
             Function<? super R, ? extends T> mapRight);
+
+    public abstract void consume(Consumer<? super L> consumerLeft,
+                                 Consumer<? super R> consumerRight);
 
     public abstract <T> Xor<L, T> map(Function<? super R, ? extends T> mapper);
 
@@ -93,6 +97,11 @@ public abstract class Xor<L, R> {
         public <T> T fold(Function<? super L, ? extends T> mapLeft,
                 Function<? super R, ? extends T> mapRight) {
             return mapLeft.apply(left);
+        }
+
+        public void consume(Consumer<? super L> consumerLeft,
+                            Consumer<? super R> consumerRight) {
+            consumerLeft.accept(left);
         }
 
         public boolean exists(Predicate<R> p) {
@@ -173,6 +182,11 @@ public abstract class Xor<L, R> {
         public <T> T fold(Function<? super L, ? extends T> mapLeft,
                 Function<? super R, ? extends T> mapRight) {
             return mapRight.apply(right);
+        }
+
+        public void consume(Consumer<? super L> consumerLeft,
+                            Consumer<? super R> consumerRight) {
+            consumerRight.accept(right);
         }
 
         public boolean exists(Predicate<R> p) {

--- a/src/main/java/com/suse/salt/netapi/utils/Xor.java
+++ b/src/main/java/com/suse/salt/netapi/utils/Xor.java
@@ -6,10 +6,17 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+/**
+ * Right biased disjunction mainly based on the Xor type from scala cats library.
+ * This type is used for collecting salt errors that are in the place of a normal result.
+ *
+ * @param <L> type of the left value
+ * @param <R> type of the right value
+ */
 public abstract class Xor<L, R> {
 
     public static <L, R> Left<L, R> left(L value) {
-       return new Left<>(value);
+        return new Left<>(value);
     }
 
     public static <L, R> Right<L, R> right(R value) {
@@ -17,22 +24,36 @@ public abstract class Xor<L, R> {
     }
 
     public abstract boolean isRight();
+
     public abstract boolean isLeft();
 
-    public abstract <T> T fold(Function<? super L, ? extends T> mapLeft, Function<? super R, ? extends T> mapRight);
+    public abstract <T> T fold(Function<? super L, ? extends T> mapLeft,
+            Function<? super R, ? extends T> mapRight);
 
     public abstract <T> Xor<L, T> map(Function<? super R, ? extends T> mapper);
-    public abstract <T> Xor<? super L, T> flatMap(Function<? super R, Xor<? super L, T>> mapper);
+
+    public abstract <T> Xor<? super L, T> flatMap(Function<? super R,
+            Xor<? super L, T>> mapper);
+
     public abstract Optional<L> left();
+
     public abstract Optional<R> right();
+
     public abstract R orElse(R value);
+
     public abstract R getOrElse(Supplier<? extends R> supplier);
+
     public abstract boolean exists(Predicate<R> p);
 
     public final Optional<R> option() {
         return right();
     }
 
+    /**
+     * Left branch of the Xor
+     * @param <L> type of the left value
+     * @param <R> type of the right value
+     */
     public static final class Left<L, R> extends Xor<L, R> {
         private final L left;
 
@@ -53,14 +74,15 @@ public abstract class Xor<L, R> {
         }
 
         public Optional<R> right() {
-           return Optional.empty();
+            return Optional.empty();
         }
 
         public <T> Xor<L, T> map(Function<? super R, ? extends T> mapper) {
             return left(left);
         }
 
-        public <T> Xor<? super L, T> flatMap(Function<? super R, Xor<? super L, T>> mapper) {
+        public <T> Xor<? super L, T> flatMap(Function<? super R,
+                Xor<? super L, T>> mapper) {
             return left(left);
         }
 
@@ -68,8 +90,9 @@ public abstract class Xor<L, R> {
             return mapper.apply(left);
         }
 
-        public <T> T fold(Function<? super L, ? extends T> mapLeft, Function<? super R, ? extends T> mapRight) {
-           return mapLeft.apply(left);
+        public <T> T fold(Function<? super L, ? extends T> mapLeft,
+                Function<? super R, ? extends T> mapRight) {
+            return mapLeft.apply(left);
         }
 
         public boolean exists(Predicate<R> p) {
@@ -91,9 +114,13 @@ public abstract class Xor<L, R> {
 
         @Override
         public boolean equals(Object obj) {
-            if (this == obj) return true;
-            else if (obj == null || getClass() != obj.getClass()) return false;
-            else return Objects.equals(left, ((Left<?, ?>) obj).left);
+            if (this == obj) {
+                return true;
+            } else if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            } else {
+                return Objects.equals(left, ((Left<?, ?>) obj).left);
+            }
         }
 
         @Override
@@ -102,6 +129,11 @@ public abstract class Xor<L, R> {
         }
     }
 
+    /**
+     * Right branch of the Xor
+     * @param <L> type of the left value
+     * @param <R> type of the right value
+     */
     public static final class Right<L, R> extends Xor<L, R> {
         private final R right;
 
@@ -129,7 +161,8 @@ public abstract class Xor<L, R> {
             return right(mapper.apply(right));
         }
 
-        public <T> Xor<? super L, T> flatMap(Function<? super R, Xor<? super L, T>> mapper) {
+        public <T> Xor<? super L, T> flatMap(Function<? super R,
+                Xor<? super L, T>> mapper) {
             return mapper.apply(right);
         }
 
@@ -137,7 +170,8 @@ public abstract class Xor<L, R> {
             return right(right);
         }
 
-        public <T> T fold(Function<? super L, ? extends T> mapLeft, Function<? super R, ? extends T> mapRight) {
+        public <T> T fold(Function<? super L, ? extends T> mapLeft,
+                Function<? super R, ? extends T> mapRight) {
             return mapRight.apply(right);
         }
 
@@ -165,9 +199,13 @@ public abstract class Xor<L, R> {
 
         @Override
         public boolean equals(Object obj) {
-            if (this == obj) return true;
-            else if (obj == null || getClass() != obj.getClass()) return false;
-            else return Objects.equals(right, ((Right<?, ?>) obj).right);
+            if (this == obj) {
+                return true;
+            } else if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            } else {
+                return Objects.equals(right, ((Right<?, ?>) obj).right);
+            }
         }
     }
 

--- a/src/main/java/com/suse/salt/netapi/utils/Xor.java
+++ b/src/main/java/com/suse/salt/netapi/utils/Xor.java
@@ -32,7 +32,7 @@ public abstract class Xor<L, R> {
             Function<? super R, ? extends T> mapRight);
 
     public abstract void consume(Consumer<? super L> consumerLeft,
-                                 Consumer<? super R> consumerRight);
+            Consumer<? super R> consumerRight);
 
     public abstract <T> Xor<L, T> map(Function<? super R, ? extends T> mapper);
 
@@ -100,7 +100,7 @@ public abstract class Xor<L, R> {
         }
 
         public void consume(Consumer<? super L> consumerLeft,
-                            Consumer<? super R> consumerRight) {
+                Consumer<? super R> consumerRight) {
             consumerLeft.accept(left);
         }
 
@@ -185,7 +185,7 @@ public abstract class Xor<L, R> {
         }
 
         public void consume(Consumer<? super L> consumerLeft,
-                            Consumer<? super R> consumerRight) {
+                Consumer<? super R> consumerRight) {
             consumerRight.accept(right);
         }
 

--- a/src/main/java/com/suse/salt/netapi/utils/Xor.java
+++ b/src/main/java/com/suse/salt/netapi/utils/Xor.java
@@ -1,0 +1,150 @@
+package com.suse.salt.netapi.utils;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+public abstract class Xor<L, R> {
+
+    public static <L, R> Left<L, R> left(L value) {
+       return new Left<>(value);
+    }
+
+    public static <L, R> Right<L, R> right(R value) {
+        return new Right<>(value);
+    }
+
+    public abstract boolean isRight();
+    public abstract boolean isLeft();
+
+    public abstract <T> T fold(Function<? super L, ? extends T> mapLeft, Function<? super R, ? extends T> mapRight);
+
+    public abstract <T> Xor<L, T> map(Function<? super R, ? extends T> mapper);
+    public abstract <T> Xor<? super L, T> flatMap(Function<? super R, Xor<? super L, T>> mapper);
+    public abstract Optional<L> left();
+    public abstract Optional<R> right();
+    public abstract R orElse(R value);
+    public abstract R getOrElse(Supplier<? extends R> supplier);
+    public abstract boolean exists(Predicate<R> p);
+
+    public final Optional<R> option() {
+        return right();
+    }
+
+    public static final class Left<L, R> extends Xor<L, R> {
+        private final L left;
+
+        private Left(L left) {
+            this.left = left;
+        }
+
+        public boolean isRight() {
+            return false;
+        }
+
+        public boolean isLeft() {
+            return true;
+        }
+
+        public Optional<L> left() {
+            return Optional.of(left);
+        }
+
+        public Optional<R> right() {
+           return Optional.empty();
+        }
+
+        public <T> Xor<L, T> map(Function<? super R, ? extends T> mapper) {
+            return left(left);
+        }
+
+        public <T> Xor<? super L, T> flatMap(Function<? super R, Xor<? super L, T>> mapper) {
+            return left(left);
+        }
+
+        public <T> Xor<T, R> leftMap(Function<? super L, Xor<T, R>> mapper) {
+            return mapper.apply(left);
+        }
+
+        public <T> T fold(Function<? super L, ? extends T> mapLeft, Function<? super R, ? extends T> mapRight) {
+           return mapLeft.apply(left);
+        }
+
+        public boolean exists(Predicate<R> p) {
+            return false;
+        }
+
+        public R orElse(R value) {
+            return value;
+        }
+
+        public R getOrElse(Supplier<? extends R> supplier) {
+            return supplier.get();
+        }
+
+        @Override
+        public String toString() {
+            return "Left(" + left.toString() + ")";
+        }
+    }
+
+    public static final class Right<L, R> extends Xor<L, R> {
+        private final R right;
+
+        private Right(R right) {
+            this.right = right;
+        }
+
+        public boolean isRight() {
+            return true;
+        }
+
+        public boolean isLeft() {
+            return false;
+        }
+
+        public Optional<L> left() {
+            return Optional.empty();
+        }
+
+        public Optional<R> right() {
+            return Optional.of(right);
+        }
+
+        public <T> Xor<L, T> map(Function<? super R, ? extends T> mapper) {
+            return right(mapper.apply(right));
+        }
+
+        public <T> Xor<? super L, T> flatMap(Function<? super R, Xor<? super L, T>> mapper) {
+            return mapper.apply(right);
+        }
+
+        public <T> Xor<T, R> leftMap(Function<? super L, Xor<T, R>> mapper) {
+            return right(right);
+        }
+
+        public <T> T fold(Function<? super L, ? extends T> mapLeft, Function<? super R, ? extends T> mapRight) {
+            return mapRight.apply(right);
+        }
+
+        public boolean exists(Predicate<R> p) {
+            return p.test(right);
+        }
+
+        public R orElse(R value) {
+            return right;
+        }
+
+        public R getOrElse(Supplier<? extends R> supplier) {
+            return right;
+        }
+
+        @Override
+        public String toString() {
+            return "Right(" + right.toString() + ")";
+        }
+
+    }
+
+}

--- a/src/main/java/com/suse/salt/netapi/utils/Xor.java
+++ b/src/main/java/com/suse/salt/netapi/utils/Xor.java
@@ -1,5 +1,6 @@
 package com.suse.salt.netapi.utils;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -87,6 +88,18 @@ public abstract class Xor<L, R> {
         public String toString() {
             return "Left(" + left.toString() + ")";
         }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            else if (obj == null || getClass() != obj.getClass()) return false;
+            else return Objects.equals(left, ((Left<?, ?>) obj).left);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash("Left", left);
+        }
     }
 
     public static final class Right<L, R> extends Xor<L, R> {
@@ -145,6 +158,17 @@ public abstract class Xor<L, R> {
             return "Right(" + right.toString() + ")";
         }
 
+        @Override
+        public int hashCode() {
+            return Objects.hash("Right", right);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            else if (obj == null || getClass() != obj.getClass()) return false;
+            else return Objects.equals(right, ((Right<?, ?>) obj).right);
+        }
     }
 
 }

--- a/src/test/java/com/suse/salt/netapi/calls/modules/SaltUtilTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/SaltUtilTest.java
@@ -126,12 +126,12 @@ public class SaltUtilTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_REFRESHPILLAR_RESPONSE)));
 
-        Map<String, Boolean> response = SaltUtil
+        Map<String, Result<Boolean>> response = SaltUtil
                 .refreshPillar(Optional.of(true), Optional.empty())
                 .callSync(client, new MinionList("minion1"));
         assertEquals(1, response.size());
         assertNotNull(response.get("minion1"));
-        Boolean data = response.get("minion1");
+        Boolean data = response.get("minion1").result().get();
         assertEquals(true, data);
     }
 }

--- a/src/test/java/com/suse/salt/netapi/calls/modules/SaltUtilTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/SaltUtilTest.java
@@ -70,7 +70,8 @@ public class SaltUtilTest {
 
         assertEquals(1, response.size());
         assertEquals("minion1", response.entrySet().iterator().next().getKey());
-        assertEquals(0, response.entrySet().iterator().next().getValue().right().get().size());
+        assertEquals(0, response.entrySet().iterator().next()
+                .getValue().right().get().size());
     }
 
     @Test
@@ -87,7 +88,8 @@ public class SaltUtilTest {
 
         assertEquals(1, response.size());
         assertEquals("minion1", response.entrySet().iterator().next().getKey());
-        assertEquals(0, response.entrySet().iterator().next().getValue().right().get().size());
+        assertEquals(0, response.entrySet().iterator().next()
+                .getValue().right().get().size());
     }
 
     @Test

--- a/src/test/java/com/suse/salt/netapi/calls/modules/SaltUtilTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/SaltUtilTest.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import com.suse.salt.netapi.results.SaltError;
+import com.suse.salt.netapi.utils.Xor;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -62,13 +64,13 @@ public class SaltUtilTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_SYNCGRAINS_RESPONSE)));
 
-        Map<String, List<String>> response = SaltUtil
+        Map<String, Xor<SaltError, List<String>>> response = SaltUtil
                 .syncGrains(Optional.of(true), Optional.empty())
                 .callSync(client, new MinionList("minion1"));
 
         assertEquals(1, response.size());
         assertEquals("minion1", response.entrySet().iterator().next().getKey());
-        assertEquals(0, response.entrySet().iterator().next().getValue().size());
+        assertEquals(0, response.entrySet().iterator().next().getValue().right().get().size());
     }
 
     @Test
@@ -79,13 +81,13 @@ public class SaltUtilTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_SYNCMODULES_RESPONSE)));
 
-        Map<String, List<String>> response = SaltUtil
+        Map<String, Xor<SaltError, List<String>>> response = SaltUtil
                 .syncModules(Optional.of(true), Optional.empty())
                 .callSync(client, new MinionList("minion1"));
 
         assertEquals(1, response.size());
         assertEquals("minion1", response.entrySet().iterator().next().getKey());
-        assertEquals(0, response.entrySet().iterator().next().getValue().size());
+        assertEquals(0, response.entrySet().iterator().next().getValue().right().get().size());
     }
 
     @Test
@@ -96,13 +98,13 @@ public class SaltUtilTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_SYNCALL_RESPONSE)));
 
-        Map<String, Map<String, Object>> response = SaltUtil
+        Map<String, Xor<SaltError, Map<String, Object>>> response = SaltUtil
                 .syncAll(Optional.of(true), Optional.empty())
                 .callSync(client, new MinionList("minion1"));
 
         assertEquals(1, response.size());
         assertNotNull(response.get("minion1"));
-        Map<String, Object> data = response.get("minion1");
+        Map<String, Object> data = response.get("minion1").right().get();
         assertEquals(0, ((List<?>) data.get("beacons")).size());
         assertEquals(0, ((List<?>) data.get("grains")).size());
         assertEquals(0, ((List<?>) data.get("log_handlers")).size());

--- a/src/test/java/com/suse/salt/netapi/calls/modules/SaltUtilTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/SaltUtilTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.results.SaltError;
 import com.suse.salt.netapi.utils.Xor;
 import org.junit.Before;
@@ -64,14 +65,14 @@ public class SaltUtilTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_SYNCGRAINS_RESPONSE)));
 
-        Map<String, Xor<SaltError, List<String>>> response = SaltUtil
+        Map<String, Result<List<String>>> response = SaltUtil
                 .syncGrains(Optional.of(true), Optional.empty())
                 .callSync(client, new MinionList("minion1"));
 
         assertEquals(1, response.size());
         assertEquals("minion1", response.entrySet().iterator().next().getKey());
         assertEquals(0, response.entrySet().iterator().next()
-                .getValue().right().get().size());
+                .getValue().result().get().size());
     }
 
     @Test
@@ -82,14 +83,14 @@ public class SaltUtilTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_SYNCMODULES_RESPONSE)));
 
-        Map<String, Xor<SaltError, List<String>>> response = SaltUtil
+        Map<String, Result<List<String>>> response = SaltUtil
                 .syncModules(Optional.of(true), Optional.empty())
                 .callSync(client, new MinionList("minion1"));
 
         assertEquals(1, response.size());
         assertEquals("minion1", response.entrySet().iterator().next().getKey());
         assertEquals(0, response.entrySet().iterator().next()
-                .getValue().right().get().size());
+                .getValue().result().get().size());
     }
 
     @Test
@@ -100,13 +101,13 @@ public class SaltUtilTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_SYNCALL_RESPONSE)));
 
-        Map<String, Xor<SaltError, Map<String, Object>>> response = SaltUtil
+        Map<String, Result<Map<String, Object>>> response = SaltUtil
                 .syncAll(Optional.of(true), Optional.empty())
                 .callSync(client, new MinionList("minion1"));
 
         assertEquals(1, response.size());
         assertNotNull(response.get("minion1"));
-        Map<String, Object> data = response.get("minion1").right().get();
+        Map<String, Object> data = response.get("minion1").result().get();
         assertEquals(0, ((List<?>) data.get("beacons")).size());
         assertEquals(0, ((List<?>) data.get("grains")).size());
         assertEquals(0, ((List<?>) data.get("log_handlers")).size());

--- a/src/test/java/com/suse/salt/netapi/calls/modules/SaltUtilTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/SaltUtilTest.java
@@ -14,8 +14,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.suse.salt.netapi.results.Result;
-import com.suse.salt.netapi.results.SaltError;
-import com.suse.salt.netapi.utils.Xor;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/com/suse/salt/netapi/calls/modules/SmbiosTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/SmbiosTest.java
@@ -13,7 +13,6 @@ import java.util.Map;
 
 import com.suse.salt.netapi.results.ModuleNotSupported;
 import com.suse.salt.netapi.results.Result;
-import com.suse.salt.netapi.results.SaltError;
 import com.suse.salt.netapi.utils.Xor;
 import org.junit.Before;
 import org.junit.Rule;
@@ -128,6 +127,7 @@ public class SmbiosTest {
         Map<String, Result<List<Smbios.Record>>> result =
                 Smbios.records(Smbios.RecordType.BIOS)
                 .callSync(client, new MinionList("minion1"));
-        assertEquals(Xor.left(new ModuleNotSupported("smbios")), result.get("minion1"));
+        assertEquals(Xor.left(new ModuleNotSupported("smbios")),
+                result.get("minion1").toXor());
     }
 }

--- a/src/test/java/com/suse/salt/netapi/calls/modules/SmbiosTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/SmbiosTest.java
@@ -63,7 +63,8 @@ public class SmbiosTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_RECORDS_RESPONSE)));
 
-        Map<String, Xor<SaltError, List<Smbios.Record>>> response = Smbios.records(Smbios.RecordType.BIOS)
+        Map<String, Xor<SaltError, List<Smbios.Record>>> response =
+                Smbios.records(Smbios.RecordType.BIOS)
                 .callSync(client, new MinionList("minion1"));
 
         assertEquals(1, response.size());
@@ -79,7 +80,8 @@ public class SmbiosTest {
         assertEquals("64 kB", record.getData().get("rom_size"));
         assertEquals("96 kB", record.getData().get("runtime_size"));
         assertEquals("SeaBIOS", record.getData().get("vendor"));
-        assertEquals("rel-1.7.5-0-ge51488c-20150524_160643-cloud127", record.getData().get("version"));
+        assertEquals("rel-1.7.5-0-ge51488c-20150524_160643-cloud127",
+                record.getData().get("version"));
     }
 
     @Test
@@ -108,7 +110,8 @@ public class SmbiosTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_EMPTY_RESPONSE)));
 
-        Map<String, Xor<SaltError, List<Smbios.Record>>> response = Smbios.records(Smbios.RecordType.BIOS)
+        Map<String, Xor<SaltError, List<Smbios.Record>>> response =
+                Smbios.records(Smbios.RecordType.BIOS)
                 .callSync(client, new MinionList("minion1"));
         assertEquals(0, response.size());
     }
@@ -121,7 +124,8 @@ public class SmbiosTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_ERROR_RESPONSE)));
 
-        Map<String, Xor<SaltError, List<Smbios.Record>>> result = Smbios.records(Smbios.RecordType.BIOS)
+        Map<String, Xor<SaltError, List<Smbios.Record>>> result =
+                Smbios.records(Smbios.RecordType.BIOS)
                 .callSync(client, new MinionList("minion1"));
         assertEquals(Xor.left(new ModuleNotSupported("smbios")), result.get("minion1"));
     }

--- a/src/test/java/com/suse/salt/netapi/calls/modules/SmbiosTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/SmbiosTest.java
@@ -11,6 +11,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
+import com.suse.salt.netapi.results.ModuleNotSupported;
 import com.suse.salt.netapi.results.SaltError;
 import com.suse.salt.netapi.utils.Xor;
 import org.junit.Before;
@@ -112,7 +113,7 @@ public class SmbiosTest {
         assertEquals(0, response.size());
     }
 
-    @Test(expected = com.google.gson.JsonSyntaxException.class)
+    @Test
     public void testErrorResponse() throws SaltException {
         stubFor(any(urlMatching("/"))
                 .willReturn(aResponse()
@@ -120,7 +121,8 @@ public class SmbiosTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_ERROR_RESPONSE)));
 
-        Smbios.records(Smbios.RecordType.BIOS)
+        Map<String, Xor<SaltError, List<Smbios.Record>>> result = Smbios.records(Smbios.RecordType.BIOS)
                 .callSync(client, new MinionList("minion1"));
+        assertEquals(Xor.left(new ModuleNotSupported("smbios")), result.get("minion1"));
     }
 }

--- a/src/test/java/com/suse/salt/netapi/calls/modules/SmbiosTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/SmbiosTest.java
@@ -11,6 +11,8 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
+import com.suse.salt.netapi.results.SaltError;
+import com.suse.salt.netapi.utils.Xor;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -60,23 +62,23 @@ public class SmbiosTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_RECORDS_RESPONSE)));
 
-        Map<String, List<Smbios.Record>> response = Smbios.records(Smbios.RecordType.BIOS)
+        Map<String, Xor<SaltError, List<Smbios.Record>>> response = Smbios.records(Smbios.RecordType.BIOS)
                 .callSync(client, new MinionList("minion1"));
 
         assertEquals(1, response.size());
-        Map.Entry<String, List<Smbios.Record>> first = response
+        Map.Entry<String, Xor<SaltError, List<Smbios.Record>>> first = response
                 .entrySet().iterator().next();
+        Smbios.Record record = first.getValue().right().get().get(0);
         assertEquals("minion1", first.getKey());
-        assertEquals("BIOS Information", first.getValue().get(0).getDescription());
-        assertEquals("0xE8000", first.getValue().get(0).getData().get("address"));
-        assertEquals(2, ((List<?>) first.getValue().get(0).getData()
+        assertEquals("BIOS Information", record.getDescription());
+        assertEquals("0xE8000", record.getData().get("address"));
+        assertEquals(2, ((List<?>) record.getData()
                 .get("characteristics")).size()) ;
-        assertEquals("04/01/2014", first.getValue().get(0).getData().get("release_date"));
-        assertEquals("64 kB", first.getValue().get(0).getData().get("rom_size"));
-        assertEquals("96 kB", first.getValue().get(0).getData().get("runtime_size"));
-        assertEquals("SeaBIOS", first.getValue().get(0).getData().get("vendor"));
-        assertEquals("rel-1.7.5-0-ge51488c-20150524_160643-cloud127", first.getValue()
-                .get(0).getData().get("version"));
+        assertEquals("04/01/2014", record.getData().get("release_date"));
+        assertEquals("64 kB", record.getData().get("rom_size"));
+        assertEquals("96 kB", record.getData().get("runtime_size"));
+        assertEquals("SeaBIOS", record.getData().get("vendor"));
+        assertEquals("rel-1.7.5-0-ge51488c-20150524_160643-cloud127", record.getData().get("version"));
     }
 
     @Test
@@ -87,14 +89,14 @@ public class SmbiosTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_ALL_RESPONSE)));
 
-        Map<String, List<Smbios.Record>> response = Smbios.records(null)
+        Map<String, Xor<SaltError, List<Smbios.Record>>> response = Smbios.records(null)
                 .callSync(client, new MinionList("minion1"));
 
         assertEquals(1, response.size());
-        Map.Entry<String, List<Smbios.Record>> first = response
+        Map.Entry<String, Xor<SaltError, List<Smbios.Record>>> first = response
                 .entrySet().iterator().next();
         assertEquals("minion1", first.getKey());
-        assertEquals(7, first.getValue().size());
+        assertEquals(7, first.getValue().right().get().size());
     }
 
     @Test
@@ -105,7 +107,7 @@ public class SmbiosTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_EMPTY_RESPONSE)));
 
-        Map<String, List<Smbios.Record>> response = Smbios.records(Smbios.RecordType.BIOS)
+        Map<String, Xor<SaltError, List<Smbios.Record>>> response = Smbios.records(Smbios.RecordType.BIOS)
                 .callSync(client, new MinionList("minion1"));
         assertEquals(0, response.size());
     }

--- a/src/test/java/com/suse/salt/netapi/calls/modules/SmbiosTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/SmbiosTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.suse.salt.netapi.results.ModuleNotSupported;
+import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.results.SaltError;
 import com.suse.salt.netapi.utils.Xor;
 import org.junit.Before;
@@ -63,14 +64,14 @@ public class SmbiosTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_RECORDS_RESPONSE)));
 
-        Map<String, Xor<SaltError, List<Smbios.Record>>> response =
+        Map<String, Result<List<Smbios.Record>>> response =
                 Smbios.records(Smbios.RecordType.BIOS)
                 .callSync(client, new MinionList("minion1"));
 
         assertEquals(1, response.size());
-        Map.Entry<String, Xor<SaltError, List<Smbios.Record>>> first = response
+        Map.Entry<String, Result<List<Smbios.Record>>> first = response
                 .entrySet().iterator().next();
-        Smbios.Record record = first.getValue().right().get().get(0);
+        Smbios.Record record = first.getValue().result().get().get(0);
         assertEquals("minion1", first.getKey());
         assertEquals("BIOS Information", record.getDescription());
         assertEquals("0xE8000", record.getData().get("address"));
@@ -92,14 +93,14 @@ public class SmbiosTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_ALL_RESPONSE)));
 
-        Map<String, Xor<SaltError, List<Smbios.Record>>> response = Smbios.records(null)
+        Map<String, Result<List<Smbios.Record>>> response = Smbios.records(null)
                 .callSync(client, new MinionList("minion1"));
 
         assertEquals(1, response.size());
-        Map.Entry<String, Xor<SaltError, List<Smbios.Record>>> first = response
+        Map.Entry<String, Result<List<Smbios.Record>>> first = response
                 .entrySet().iterator().next();
         assertEquals("minion1", first.getKey());
-        assertEquals(7, first.getValue().right().get().size());
+        assertEquals(7, first.getValue().result().get().size());
     }
 
     @Test
@@ -110,7 +111,7 @@ public class SmbiosTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_EMPTY_RESPONSE)));
 
-        Map<String, Xor<SaltError, List<Smbios.Record>>> response =
+        Map<String, Result<List<Smbios.Record>>> response =
                 Smbios.records(Smbios.RecordType.BIOS)
                 .callSync(client, new MinionList("minion1"));
         assertEquals(0, response.size());
@@ -124,7 +125,7 @@ public class SmbiosTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody(JSON_ERROR_RESPONSE)));
 
-        Map<String, Xor<SaltError, List<Smbios.Record>>> result =
+        Map<String, Result<List<Smbios.Record>>> result =
                 Smbios.records(Smbios.RecordType.BIOS)
                 .callSync(client, new MinionList("minion1"));
         assertEquals(Xor.left(new ModuleNotSupported("smbios")), result.get("minion1"));

--- a/src/test/java/com/suse/salt/netapi/calls/modules/TestTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/TestTest.java
@@ -1,6 +1,7 @@
 package com.suse.salt.netapi.calls.modules;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
 import java.io.InputStream;
@@ -39,9 +40,9 @@ public class TestTest {
         assertEquals("3.13.0-65-generic", parsed.getSystem().get("release"));
         assertEquals("Ubuntu 14.04 trusty", parsed.getSystem().get("dist"));
         assertEquals("Ubuntu 14.04 trusty", parsed.getSystem().get("system"));
-        assertNull(parsed.getDependencies().get("cherrypy"));
+        assertFalse(parsed.getDependencies().get("cherrypy").isPresent());
         assertEquals("2.7.6 (default, Jun 22 2015, 17:58:13)",
-                parsed.getDependencies().get("Python"));
+                parsed.getDependencies().get("Python").get());
         assertEquals(25, parsed.getDependencies().size());
     }
 

--- a/src/test/java/com/suse/salt/netapi/calls/modules/TestTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/TestTest.java
@@ -2,7 +2,6 @@ package com.suse.salt.netapi.calls.modules;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 
 import java.io.InputStream;
 import java.util.Optional;

--- a/src/test/java/com/suse/salt/netapi/examples/Calls.java
+++ b/src/test/java/com/suse/salt/netapi/examples/Calls.java
@@ -10,10 +10,14 @@ import com.suse.salt.netapi.datatypes.target.Glob;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.salt.netapi.datatypes.target.Target;
 import com.suse.salt.netapi.exception.SaltException;
+import com.suse.salt.netapi.results.SaltError;
+import com.suse.salt.netapi.utils.Xor;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 /**
  * Example code calling salt modules using the generic interface.
@@ -30,7 +34,7 @@ public class Calls {
 
         // Ping all minions using a glob matcher
         Target<String> globTarget = new Glob("*");
-        Map<String, Boolean> results = Test.ping().callSync(
+        Map<String, Xor<SaltError, Boolean>> results = Test.ping().callSync(
                 client, globTarget, USER, PASSWORD, AuthModule.AUTO);
 
         System.out.println("--> Ping results:\n");
@@ -38,12 +42,17 @@ public class Calls {
 
         // Get the grains from a list of minions
         Target<List<String>> minionList = new MinionList("minion1", "minion2");
-        Map<String, Map<String, Object>> grainResults = Grains.items(false).callSync(
+        Map<String, Xor<SaltError, Map<String, Object>>> grainResults = Grains.items(false).callSync(
                 client, minionList, USER, PASSWORD, AuthModule.AUTO);
 
         grainResults.forEach((minion, grains) -> {
             System.out.println("\n--> Listing grains for '" + minion + "':\n");
-            grains.forEach((key, value) -> System.out.println(key + ": " + value));
+            String message = grains.fold(
+                    Object::toString,
+                    m -> m.entrySet().stream()
+                            .map(e -> e.getKey() + ": " + e.getValue())
+                            .collect(Collectors.joining("\n"))
+            );
         });
 
         // Call a wheel function: list accepted and pending minion keys
@@ -52,8 +61,8 @@ public class Calls {
         Key.Names keys = keyResults.getData().getResult();
 
         System.out.println("\n--> Accepted minion keys:\n");
-        keys.getMinions().forEach(minion -> System.out.println(minion));
+        keys.getMinions().forEach(System.out::println);
         System.out.println("\n--> Pending minion keys:\n");
-        keys.getUnacceptedMinions().forEach(minion -> System.out.println(minion));
+        keys.getUnacceptedMinions().forEach(System.out::println);
     }
 }

--- a/src/test/java/com/suse/salt/netapi/examples/Calls.java
+++ b/src/test/java/com/suse/salt/netapi/examples/Calls.java
@@ -11,8 +11,6 @@ import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.salt.netapi.datatypes.target.Target;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.results.Result;
-import com.suse.salt.netapi.results.SaltError;
-import com.suse.salt.netapi.utils.Xor;
 
 import java.net.URI;
 import java.util.List;

--- a/src/test/java/com/suse/salt/netapi/examples/Calls.java
+++ b/src/test/java/com/suse/salt/netapi/examples/Calls.java
@@ -10,6 +10,7 @@ import com.suse.salt.netapi.datatypes.target.Glob;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.salt.netapi.datatypes.target.Target;
 import com.suse.salt.netapi.exception.SaltException;
+import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.results.SaltError;
 import com.suse.salt.netapi.utils.Xor;
 
@@ -33,7 +34,7 @@ public class Calls {
 
         // Ping all minions using a glob matcher
         Target<String> globTarget = new Glob("*");
-        Map<String, Xor<SaltError, Boolean>> results = Test.ping().callSync(
+        Map<String, Result<Boolean>> results = Test.ping().callSync(
                 client, globTarget, USER, PASSWORD, AuthModule.AUTO);
 
         System.out.println("--> Ping results:\n");
@@ -41,7 +42,7 @@ public class Calls {
 
         // Get the grains from a list of minions
         Target<List<String>> minionList = new MinionList("minion1", "minion2");
-        Map<String, Xor<SaltError, Map<String, Object>>> grainResults =
+        Map<String, Result<Map<String, Object>>> grainResults =
                 Grains.items(false).callSync(
                 client, minionList, USER, PASSWORD, AuthModule.AUTO);
 

--- a/src/test/java/com/suse/salt/netapi/examples/Calls.java
+++ b/src/test/java/com/suse/salt/netapi/examples/Calls.java
@@ -16,7 +16,6 @@ import com.suse.salt.netapi.utils.Xor;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 /**
@@ -42,7 +41,8 @@ public class Calls {
 
         // Get the grains from a list of minions
         Target<List<String>> minionList = new MinionList("minion1", "minion2");
-        Map<String, Xor<SaltError, Map<String, Object>>> grainResults = Grains.items(false).callSync(
+        Map<String, Xor<SaltError, Map<String, Object>>> grainResults =
+                Grains.items(false).callSync(
                 client, minionList, USER, PASSWORD, AuthModule.AUTO);
 
         grainResults.forEach((minion, grains) -> {
@@ -50,8 +50,8 @@ public class Calls {
             String message = grains.fold(
                     Object::toString,
                     m -> m.entrySet().stream()
-                            .map(e -> e.getKey() + ": " + e.getValue())
-                            .collect(Collectors.joining("\n"))
+                    .map(e -> e.getKey() + ": " + e.getValue())
+                    .collect(Collectors.joining("\n"))
             );
         });
 

--- a/src/test/java/com/suse/salt/netapi/examples/Calls.java
+++ b/src/test/java/com/suse/salt/netapi/examples/Calls.java
@@ -48,8 +48,8 @@ public class Calls {
             String grainsOutput = grains.fold(
                     error -> "Error: " + error.toString(),
                     grainsMap -> grainsMap.entrySet().stream()
-                            .map(e -> e.getKey() + ": " + e.getValue())
-                            .collect(Collectors.joining("\n"))
+                    .map(e -> e.getKey() + ": " + e.getValue())
+                    .collect(Collectors.joining("\n"))
             );
             System.out.println(grainsOutput);
         });

--- a/src/test/java/com/suse/salt/netapi/examples/Calls.java
+++ b/src/test/java/com/suse/salt/netapi/examples/Calls.java
@@ -40,18 +40,18 @@ public class Calls {
 
         // Get the grains from a list of minions
         Target<List<String>> minionList = new MinionList("minion1", "minion2");
-        Map<String, Result<Map<String, Object>>> grainResults =
-                Grains.items(false).callSync(
-                client, minionList, USER, PASSWORD, AuthModule.AUTO);
+        Map<String, Result<Map<String, Object>>> grainResults = Grains.items(false)
+                .callSync(client, minionList, USER, PASSWORD, AuthModule.AUTO);
 
         grainResults.forEach((minion, grains) -> {
             System.out.println("\n--> Listing grains for '" + minion + "':\n");
-            String message = grains.fold(
-                    Object::toString,
-                    m -> m.entrySet().stream()
-                    .map(e -> e.getKey() + ": " + e.getValue())
-                    .collect(Collectors.joining("\n"))
+            String grainsOutput = grains.fold(
+                    error -> "Error: " + error.toString(),
+                    grainsMap -> grainsMap.entrySet().stream()
+                            .map(e -> e.getKey() + ": " + e.getValue())
+                            .collect(Collectors.joining("\n"))
             );
+            System.out.println(grainsOutput);
         });
 
         // Call a wheel function: list accepted and pending minion keys

--- a/src/test/java/com/suse/salt/netapi/parser/JsonParserTest.java
+++ b/src/test/java/com/suse/salt/netapi/parser/JsonParserTest.java
@@ -105,21 +105,21 @@ public class JsonParserTest {
         assertEquals(93.5, applications.getWritesPerRequest(), 0);
 
         Request req1 = applications.getRequests().get("140691837540096");
-        assertEquals(new Integer(54), req1.getBytesRead());
-        assertEquals(new Integer(187), req1.getBytesWritten());
-        assertEquals("200 OK", req1.getResponeStatus());
+        assertEquals(new Integer(54), req1.getBytesRead().get());
+        assertEquals(new Integer(187), req1.getBytesWritten().get());
+        assertEquals("200 OK", req1.getResponeStatus().get());
         assertEquals(new Date(1425821772580L), req1.getStartTime());
-        assertEquals(new Date(1425821772645L), req1.getEndTime());
+        assertEquals(new Date(1425821772645L), req1.getEndTime().get());
         assertEquals("127.0.0.1:45009", req1.getClient());
         assertEquals(0.06533312797546387, req1.getProcessingTime(), 0);
         assertEquals("POST /login HTTP/1.1", req1.getRequestLine());
 
         Request req2 = applications.getRequests().get("140691829147392");
-        assertEquals(null, req2.getBytesRead());
-        assertEquals(null, req2.getBytesWritten());
-        assertEquals(null, req2.getResponeStatus());
+        assertFalse(req2.getBytesRead().isPresent());
+        assertFalse(req2.getBytesWritten().isPresent());
+        assertFalse(req2.getResponeStatus().isPresent());
         assertEquals(new Date(1425821785119L), req2.getStartTime());
-        assertEquals(null, req2.getEndTime());
+        assertFalse(req2.getEndTime().isPresent());
         assertEquals("127.0.0.1:45015", req2.getClient());
         assertEquals(0.0002930164337158203, req2.getProcessingTime(), 0);
         assertEquals("GET /stats HTTP/1.1", req2.getRequestLine());

--- a/src/test/java/com/suse/salt/netapi/parser/JsonParserTest.java
+++ b/src/test/java/com/suse/salt/netapi/parser/JsonParserTest.java
@@ -10,7 +10,7 @@ import com.suse.salt.netapi.datatypes.cherrypy.HttpServer;
 import com.suse.salt.netapi.datatypes.cherrypy.Request;
 import com.suse.salt.netapi.datatypes.cherrypy.ServerThread;
 import com.suse.salt.netapi.datatypes.cherrypy.Stats;
-import com.suse.salt.netapi.results.Result;
+import com.suse.salt.netapi.results.Return;
 
 import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
@@ -39,7 +39,7 @@ public class JsonParserTest {
     @Test
     public void testJobsParser() throws Exception {
         InputStream is = getClass().getResourceAsStream("/minions_response.json");
-        Result<List<ScheduledJob>> result = JsonParser.SCHEDULED_JOB.parse(is);
+        Return<List<ScheduledJob>> result = JsonParser.SCHEDULED_JOB.parse(is);
         assertNotNull("failed to parse", result);
         String jid = result.getResult().get(0).getJid();
         assertEquals("unable to parse jid", "20150211105524392307", jid);
@@ -48,14 +48,14 @@ public class JsonParserTest {
     @Test
     public void testStringParser() throws Exception {
         InputStream is = getClass().getResourceAsStream("/logout_response.json");
-        Result<String> result = JsonParser.STRING.parse(is);
+        Return<String> result = JsonParser.STRING.parse(is);
         assertNotNull(result);
     }
 
     @Test
     public void testTokenParser() throws Exception {
         InputStream is = getClass().getResourceAsStream("/login_response.json");
-        Result<List<Token>> result = JsonParser.TOKEN.parse(is);
+        Return<List<Token>> result = JsonParser.TOKEN.parse(is);
         assertNotNull(result);
         assertEquals("user", result.getResult().get(0).getUser());
         assertEquals("auto", result.getResult().get(0).getEauth());
@@ -156,7 +156,7 @@ public class JsonParserTest {
     @Test
     public void testKeysParser() throws Exception {
         InputStream is = getClass().getResourceAsStream("/keys_response.json");
-        Result<Key.Names> result = JsonParser.KEYS.parse(is);
+        Return<Key.Names> result = JsonParser.KEYS.parse(is);
         Key.Names keys = result.getResult();
         assertNotNull("failed to parse", result);
         assertEquals(Arrays.asList("master.pem", "master.pub"), keys.getLocal());
@@ -168,7 +168,7 @@ public class JsonParserTest {
     @Test
     public void testJobsWithArgsParser() throws Exception {
         InputStream is = this.getClass().getResourceAsStream("/jobs_response.json");
-        Result<List<Map<String, Job>>> result = JsonParser.JOBS.parse(is);
+        Return<List<Map<String, Job>>> result = JsonParser.JOBS.parse(is);
         assertNotNull("failed to parse", result);
 
         Map<String, Job> jobs = result.getResult().get(0);
@@ -187,7 +187,7 @@ public class JsonParserTest {
     @Test
     public void testJobsWithKwargsParser() throws Exception {
         InputStream is = this.getClass().getResourceAsStream("/jobs_response_kwargs.json");
-        Result<List<Map<String, Job>>> result = JsonParser.JOBS.parse(is);
+        Return<List<Map<String, Job>>> result = JsonParser.JOBS.parse(is);
         assertNotNull("failed to parse", result);
 
         Map<String, Job> jobs = result.getResult().get(0);
@@ -245,7 +245,7 @@ public class JsonParserTest {
     public void testJobsWithArgsAsKwargsParser() throws Exception {
         InputStream is = this.getClass()
                 .getResourceAsStream("/jobs_response_args_as_kwargs.json");
-        Result<List<Map<String, Job>>> result = JsonParser.JOBS.parse(is);
+        Return<List<Map<String, Job>>> result = JsonParser.JOBS.parse(is);
 
         Map<String, Job> jobs = result.getResult().get(0);
         Job job = jobs.get("20150315163041425361");
@@ -292,7 +292,7 @@ public class JsonParserTest {
     public void testJobsMultipleKwargs() throws Exception {
         InputStream is = this.getClass()
                 .getResourceAsStream("/jobs_response_multiple_kwarg.json");
-        Result<List<Map<String, Job>>> result = JsonParser.JOBS.parse(is);
+        Return<List<Map<String, Job>>> result = JsonParser.JOBS.parse(is);
 
         Map<String, Job> jobs = result.getResult().get(0);
         Job job = jobs.get("20150306023815935637");


### PR DESCRIPTION
This adds better error handling for `LocalCall`. Certain errors from salt just result in having a string with an error message in place where the result should be. This leads most of the time to parsing errors since the expected result type is not always string. The `Xor` type will handle this by parsing either the result type or if that fails parse the error message into a subtype of `SaltError`. This also means there is now an explicit error handling step once you got your `Xor` with a potential result.
This error handling is heuristic based since the error string is indistinguishable from a function that returns successfully with a string formatted like a salt error. In case a call returns string it will contain the error string in the success case. This may be changed in the future tho.
One side effect of this error handling now is that `Xor` will also capture any parsing errors downstream and return a `GenericSaltError`.