### PR TITLE
Synchronous module calls via salt-ssh

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -202,21 +202,38 @@ public class LocalCall<R> implements Call<R> {
 
     /**
      * Call an execution module function on the given target via salt-ssh and synchronously
+     * wait for the result. This call uses default values for all the available options.
+     *
+     * @param client SaltClient instance
+     * @param target the target for the function
+     * @return a map containing the results with the minion name as key
+     * @throws SaltException if anything goes wrong
+     */
+    public Map<String, Result<SSHResult<R>>> callSyncSSH(final SaltClient client,
+            Target<?> target) throws SaltException {
+        return callSyncSSH(client, target, Optional.empty(), Optional.empty());
+    }
+
+    /**
+     * Call an execution module function on the given target via salt-ssh and synchronously
      * wait for the result.
      *
      * @param client SaltClient instance
      * @param target the target for the function
      * @param rosterFile optional roster file (default: /etc/salt/roster)
+     * @param ignoreHostKeys use this option to disable 'StrictHostKeyChecking'
      * @return a map containing the results with the minion name as key
      * @throws SaltException if anything goes wrong
      */
     public Map<String, Result<SSHResult<R>>> callSyncSSH(final SaltClient client,
-            Target<?> target, Optional<String> rosterFile) throws SaltException {
+            Target<?> target, Optional<String> rosterFile, Optional<Boolean> ignoreHostKeys)
+            throws SaltException {
         Map<String, Object> customArgs = new HashMap<>();
         customArgs.putAll(getPayload());
         customArgs.put("tgt", target.getTarget());
         customArgs.put("expr_form", target.getType());
-        rosterFile.ifPresent(r -> customArgs.put("roster_file", r));
+        rosterFile.ifPresent(value -> customArgs.put("roster_file", value));
+        ignoreHostKeys.ifPresent(value -> customArgs.put("ignore_host_keys", value));
 
         Type xor = parameterizedType(null, Result.class,
                 parameterizedType(null, SSHResult.class, getReturnType().getType()));

--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -8,6 +8,7 @@ import com.suse.salt.netapi.datatypes.target.Target;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.results.Return;
+import com.suse.salt.netapi.results.SSHResult;
 
 import com.google.gson.reflect.TypeToken;
 
@@ -209,24 +210,25 @@ public class LocalCall<R> implements Call<R> {
      * @return a map containing the results with the minion name as key
      * @throws SaltException if anything goes wrong
      */
-    public Map<String, Result<R>> callSyncSSH(final SaltClient client, Target<?> target,
-            Optional<String> rosterFile) throws SaltException {
+    public Map<String, Result<SSHResult<R>>> callSyncSSH(final SaltClient client,
+            Target<?> target, Optional<String> rosterFile) throws SaltException {
         Map<String, Object> customArgs = new HashMap<>();
         customArgs.putAll(getPayload());
         customArgs.put("tgt", target.getTarget());
         customArgs.put("expr_form", target.getType());
         rosterFile.ifPresent(r -> customArgs.put("roster_file", r));
 
-        Type xor = parameterizedType(null, Result.class, getReturnType().getType());
+        Type xor = parameterizedType(null, Result.class,
+                parameterizedType(null, SSHResult.class, getReturnType().getType()));
         Type map = parameterizedType(null, Map.class, String.class, xor);
         Type listType = parameterizedType(null, List.class, map);
         Type wrapperType = parameterizedType(null, Return.class, listType);
 
         @SuppressWarnings("unchecked")
-        Return<List<Map<String, Result<R>>>> wrapper = client.call(this,
+        Return<List<Map<String, Result<SSHResult<R>>>>> wrapper = client.call(this,
                 Client.SSH, "/run",
                 Optional.of(customArgs),
-                (TypeToken<Return<List<Map<String, Result<R>>>>>)
+                (TypeToken<Return<List<Map<String, Result<SSHResult<R>>>>>>)
                 TypeToken.get(wrapperType));
         return wrapper.getResult().get(0);
     }

--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -211,7 +211,8 @@ public class LocalCall<R> implements Call<R> {
      */
     public Map<String, Result<SSHResult<R>>> callSyncSSH(final SaltClient client,
             Target<?> target) throws SaltException {
-        return callSyncSSH(client, target, Optional.empty(), Optional.empty());
+        return callSyncSSH(client, target, Optional.empty(), Optional.empty(),
+                Optional.empty());
     }
 
     /**
@@ -222,18 +223,20 @@ public class LocalCall<R> implements Call<R> {
      * @param target the target for the function
      * @param rosterFile optional roster file (default: /etc/salt/roster)
      * @param ignoreHostKeys use this option to disable 'StrictHostKeyChecking'
+     * @param sudo run command via sudo (default: false)
      * @return a map containing the results with the minion name as key
      * @throws SaltException if anything goes wrong
      */
     public Map<String, Result<SSHResult<R>>> callSyncSSH(final SaltClient client,
-            Target<?> target, Optional<String> rosterFile, Optional<Boolean> ignoreHostKeys)
-            throws SaltException {
+            Target<?> target, Optional<String> rosterFile, Optional<Boolean> ignoreHostKeys,
+            Optional<Boolean> sudo) throws SaltException {
         Map<String, Object> customArgs = new HashMap<>();
         customArgs.putAll(getPayload());
         customArgs.put("tgt", target.getTarget());
         customArgs.put("expr_form", target.getType());
         rosterFile.ifPresent(value -> customArgs.put("roster_file", value));
         ignoreHostKeys.ifPresent(value -> customArgs.put("ignore_host_keys", value));
+        sudo.ifPresent(value -> customArgs.put("ssh_sudo", value));
 
         Type xor = parameterizedType(null, Result.class,
                 parameterizedType(null, SSHResult.class, getReturnType().getType()));

--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -224,7 +224,7 @@ public class LocalCall<R> implements Call<R> {
         cfg.getKeyDeploy().ifPresent(v -> args.put("ssh_key_deploy", v));
         cfg.getNoHostKeys().ifPresent(v -> args.put("no_host_keys", v));
         cfg.getPasswd().ifPresent(v -> args.put("ssh_passwd", v));
-        cfg.getPrivateKeyFile().ifPresent(v -> args.put("ssh_priv", v));
+        cfg.getPriv().ifPresent(v -> args.put("ssh_priv", v));
         cfg.getRawShell().ifPresent(v -> args.put("raw_shell", v));
         cfg.getRefreshCache().ifPresent(v -> args.put("refresh_cache", v));
         cfg.getRemotePortForwards().ifPresent(v -> args.put("ssh_remote_port_forwards", v));

--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -206,25 +206,36 @@ public class LocalCall<R> implements Call<R> {
      *
      * @param client SaltClient instance
      * @param target the target for the function
-     * @param config Salt SSH configuration object
+     * @param cfg Salt SSH configuration object
      * @return a map containing the results with the minion name as key
      * @throws SaltException if anything goes wrong
      */
     public Map<String, Result<SSHResult<R>>> callSyncSSH(final SaltClient client,
-            Target<?> target, SaltSSHConfig config) throws SaltException {
-        Map<String, Object> customArgs = new HashMap<>();
-        customArgs.putAll(getPayload());
-        customArgs.put("tgt", target.getTarget());
-        customArgs.put("expr_form", target.getType());
+            Target<?> target, SaltSSHConfig cfg) throws SaltException {
+        Map<String, Object> args = new HashMap<>();
+        args.putAll(getPayload());
+        args.put("tgt", target.getTarget());
+        args.put("expr_form", target.getType());
 
         // Map config properties to arguments
-        config.getIgnoreHostKeys().ifPresent(
-                value -> customArgs.put("ignore_host_keys", value));
-        config.getNoHostKeys().ifPresent(value -> customArgs.put("no_host_keys", value));
-        config.getPrivateKeyFile().ifPresent(value -> customArgs.put("ssh_priv", value));
-        config.getRoster().ifPresent(value -> customArgs.put("roster", value));
-        config.getRosterFile().ifPresent(value -> customArgs.put("roster_file", value));
-        config.getSudo().ifPresent(value -> customArgs.put("ssh_sudo", value));
+        cfg.getExtraFilerefs().ifPresent(v -> args.put("extra_filerefs", v));
+        cfg.getIdentitiesOnly().ifPresent(v -> args.put("ssh_identities_only", v));
+        cfg.getIgnoreHostKeys().ifPresent(v -> args.put("ignore_host_keys", v));
+        cfg.getKeyDeploy().ifPresent(v -> args.put("ssh_key_deploy", v));
+        cfg.getNoHostKeys().ifPresent(v -> args.put("no_host_keys", v));
+        cfg.getPasswd().ifPresent(v -> args.put("ssh_passwd", v));
+        cfg.getPrivateKeyFile().ifPresent(v -> args.put("ssh_priv", v));
+        cfg.getRawShell().ifPresent(v -> args.put("raw_shell", v));
+        cfg.getRefreshCache().ifPresent(v -> args.put("refresh_cache", v));
+        cfg.getRemotePortForwards().ifPresent(v -> args.put("ssh_remote_port_forwards", v));
+        cfg.getRoster().ifPresent(v -> args.put("roster", v));
+        cfg.getRosterFile().ifPresent(v -> args.put("roster_file", v));
+        cfg.getScanPorts().ifPresent(v -> args.put("ssh_scan_ports", v));
+        cfg.getScanTimeout().ifPresent(v -> args.put("ssh_scan_timeout", v));
+        cfg.getSudo().ifPresent(v -> args.put("ssh_sudo", v));
+        cfg.getSSHMaxProcs().ifPresent(v -> args.put("ssh_max_procs", v));
+        cfg.getUser().ifPresent(v -> args.put("ssh_user", v));
+        cfg.getWipe().ifPresent(v -> args.put("ssh_wipe", v));
 
         Type xor = parameterizedType(null, Result.class,
                 parameterizedType(null, SSHResult.class, getReturnType().getType()));
@@ -235,7 +246,7 @@ public class LocalCall<R> implements Call<R> {
         @SuppressWarnings("unchecked")
         Return<List<Map<String, Result<SSHResult<R>>>>> wrapper = client.call(this,
                 Client.SSH, "/run",
-                Optional.of(customArgs),
+                Optional.of(args),
                 (TypeToken<Return<List<Map<String, Result<SSHResult<R>>>>>>)
                 TypeToken.get(wrapperType));
         return wrapper.getResult().get(0);

--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -206,9 +206,7 @@ public class LocalCall<R> implements Call<R> {
      *
      * @param client SaltClient instance
      * @param target the target for the function
-     * @param rosterFile optional roster file (default: /etc/salt/roster)
-     * @param ignoreHostKeys use this option to disable 'StrictHostKeyChecking'
-     * @param sudo run command via sudo (default: false)
+     * @param config Salt SSH configuration object
      * @return a map containing the results with the minion name as key
      * @throws SaltException if anything goes wrong
      */

--- a/src/main/java/com/suse/salt/netapi/calls/SaltSSHConfig.java
+++ b/src/main/java/com/suse/salt/netapi/calls/SaltSSHConfig.java
@@ -7,32 +7,84 @@ import java.util.Optional;
  */
 public class SaltSSHConfig {
 
+    private final Optional<String> extraFilerefs;
+    private final Optional<Boolean> identitiesOnly;
     private final Optional<Boolean> ignoreHostKeys;
+    private final Optional<Boolean> keyDeploy;
     private final Optional<Boolean> noHostKeys;
+    private final Optional<String> passwd;
     private final Optional<String> privateKeyFile;
+    private final Optional<Boolean> rawShell;
+    private final Optional<Boolean> refreshCache;
+    private final Optional<String> remotePortForwards;
     private final Optional<String> roster;
     private final Optional<String> rosterFile;
+    private final Optional<String> scanPorts;
+    private final Optional<Double> scanTimeout;
+    private final Optional<Integer> sshMaxProcs;
     private final Optional<Boolean> sudo;
+    private final Optional<String> user;
+    private final Optional<Boolean> wipe;
 
     private SaltSSHConfig(Builder builder) {
+        extraFilerefs = builder.extraFilerefs;
+        identitiesOnly = builder.identitiesOnly;
         ignoreHostKeys = builder.ignoreHostKeys;
+        keyDeploy = builder.keyDeploy;
         noHostKeys = builder.noHostKeys;
+        passwd = builder.passwd;
         privateKeyFile = builder.privateKeyFile;
+        rawShell = builder.rawShell;
+        refreshCache = builder.refreshCache;
+        remotePortForwards = builder.remotePortForwards;
         roster = builder.roster;
         rosterFile = builder.rosterFile;
+        scanPorts = builder.scanPorts;
+        scanTimeout = builder.scanTimeout;
+        sshMaxProcs = builder.sshMaxProcs;
         sudo = builder.sudo;
+        user = builder.user;
+        wipe = builder.wipe;
+    }
+
+    public Optional<String> getExtraFilerefs() {
+        return extraFilerefs;
+    }
+
+    public Optional<Boolean> getIdentitiesOnly() {
+        return identitiesOnly;
     }
 
     public Optional<Boolean> getIgnoreHostKeys() {
         return ignoreHostKeys;
     }
 
+    public Optional<Boolean> getKeyDeploy() {
+        return keyDeploy;
+    }
+
     public Optional<Boolean> getNoHostKeys() {
         return noHostKeys;
     }
 
+    public Optional<String> getPasswd() {
+        return passwd;
+    }
+
     public Optional<String> getPrivateKeyFile() {
         return privateKeyFile;
+    }
+
+    public Optional<Boolean> getRawShell() {
+        return rawShell;
+    }
+
+    public Optional<Boolean> getRefreshCache() {
+        return refreshCache;
+    }
+
+    public Optional<String> getRemotePortForwards() {
+        return remotePortForwards;
     }
 
     public Optional<String> getRoster() {
@@ -43,8 +95,28 @@ public class SaltSSHConfig {
         return rosterFile;
     }
 
+    public Optional<String> getScanPorts() {
+        return scanPorts;
+    }
+
+    public Optional<Double> getScanTimeout() {
+        return scanTimeout;
+    }
+
+    public Optional<Integer> getSSHMaxProcs() {
+        return sshMaxProcs;
+    }
+
     public Optional<Boolean> getSudo() {
         return sudo;
+    }
+
+    public Optional<String> getUser() {
+        return user;
+    }
+
+    public Optional<Boolean> getWipe() {
+        return wipe;
     }
 
     /**
@@ -52,21 +124,56 @@ public class SaltSSHConfig {
      */
     public static class Builder {
 
+        private Optional<String> extraFilerefs = Optional.empty();
+        private Optional<Boolean> identitiesOnly = Optional.empty();
         private Optional<Boolean> ignoreHostKeys = Optional.empty();
+        private Optional<Boolean> keyDeploy = Optional.empty();
         private Optional<Boolean> noHostKeys = Optional.empty();
+        private Optional<String> passwd = Optional.empty();
         private Optional<String> privateKeyFile = Optional.empty();
+        private Optional<Boolean> rawShell = Optional.empty();
+        private Optional<Boolean> refreshCache = Optional.empty();
+        private Optional<String> remotePortForwards = Optional.empty();
         private Optional<String> roster = Optional.empty();
         private Optional<String> rosterFile = Optional.empty();
+        private Optional<String> scanPorts = Optional.empty();
+        private Optional<Double> scanTimeout = Optional.empty();
         private Optional<Boolean> sudo = Optional.empty();
+        private Optional<Integer> sshMaxProcs = Optional.empty();
+        private Optional<String> user = Optional.empty();
+        private Optional<Boolean> wipe = Optional.empty();
 
         public Builder() {
+        }
+
+        /**
+         * Pass in extra files to include in the state tarball.
+         *
+         * @param extraFilerefs the value to set
+         * @return this builder
+         */
+        public Builder extraFilerefs(String extraFilerefs) {
+            this.extraFilerefs = Optional.of(extraFilerefs);
+            return this;
+        }
+
+        /**
+         * Use the only authentication identity files configured in the ssh_config files.
+         * See IdentitiesOnly flag in man ssh_config.
+         *
+         * @param identitiesOnly the value to set
+         * @return this builder
+         */
+        public Builder identitiesOnly(boolean identitiesOnly) {
+            this.identitiesOnly = Optional.of(identitiesOnly);
+            return this;
         }
 
         /**
          * By default ssh host keys are honored and connections will ask for approval. Use
          * this option to disable 'StrictHostKeyChecking.'
          *
-         * @param ignoreHostKeys the value
+         * @param ignoreHostKeys the value to set
          * @return this builder
          */
         public Builder ignoreHostKeys(boolean ignoreHostKeys) {
@@ -75,9 +182,21 @@ public class SaltSSHConfig {
         }
 
         /**
+         * Set this flag to attempt to deploy the authorized ssh key with all minions. This
+         * combined with --passwd can make initial deployment of keys very fast and easy.
+         *
+         * @param keyDeploy the value to set
+         * @return this builder
+         */
+        public Builder keyDeploy(boolean keyDeploy) {
+            this.keyDeploy = Optional.of(keyDeploy);
+            return this;
+        }
+
+        /**
          * Removes all host key checking functionality from SSH session.
          *
-         * @param noHostKeys the value
+         * @param noHostKeys the value the value to set
          * @return this builder
          */
         public Builder noHostKeys(boolean noHostKeys) {
@@ -86,9 +205,20 @@ public class SaltSSHConfig {
         }
 
         /**
+         * Set the default password to attempt to use when authenticating.
+         *
+         * @param passwd the value to set
+         * @return this builder
+         */
+        public Builder passwd(String passwd) {
+            this.passwd = Optional.of(passwd);
+            return this;
+        }
+
+        /**
          * SSH private key file.
          *
-         * @param privateKeyFile path to the file
+         * @param privateKeyFile the value to set
          * @return this builder
          */
         public Builder privateKeyFile(String privateKeyFile) {
@@ -97,10 +227,48 @@ public class SaltSSHConfig {
         }
 
         /**
+         * Select a random temp dir to deploy on the remote system. The dir will be cleaned
+         * after the execution.
+         *
+         * @param rawShell the value to set
+         * @return this builder
+         */
+        public Builder rawShell(boolean rawShell) {
+            this.rawShell = Optional.of(rawShell);
+            return this;
+        }
+
+        /**
+         * Force a refresh of the master side data cache of the target's data. This is
+         * needed if a target's grains have been changed and the auto refresh timeframe has
+         * not been reached.
+         *
+         * @param refreshCache the value to set
+         * @return this builder
+         */
+        public Builder refreshCache(boolean refreshCache) {
+            this.refreshCache = Optional.of(refreshCache);
+            return this;
+        }
+
+        /**
+         * Setup remote port forwarding using the same syntax as with the -R parameter of
+         * ssh. A comma separated list of port forwarding definitions will be translated
+         * into multiple -R parameters.
+         *
+         * @param remotePortForwards the value to set
+         * @return this builder
+         */
+        public Builder remotePortForwards(String remotePortForwards) {
+            this.remotePortForwards = Optional.of(remotePortForwards);
+            return this;
+        }
+
+        /**
          * Define which roster system to use, this defines if a database backend, scanner,
          * or custom roster system is used. Default: 'flat'.
          *
-         * @param roster the roster system to use
+         * @param roster the value to set
          * @return this builder
          */
         public Builder roster(String roster) {
@@ -113,7 +281,7 @@ public class SaltSSHConfig {
          * roster file is called roster and is found in the same directory as the master
          * config file.
          *
-         * @param rosterFile the roster file location
+         * @param rosterFile the value to set
          * @return this builder
          */
         public Builder rosterFile(String rosterFile) {
@@ -122,13 +290,70 @@ public class SaltSSHConfig {
         }
 
         /**
+         * Comma-separated list of ports to scan in the scan roster.
+         *
+         * @param scanPorts the value to set
+         * @return this builder
+         */
+        public Builder scanPorts(String scanPorts) {
+            this.scanPorts = Optional.of(scanPorts);
+            return this;
+        }
+
+        /**
+         * Scanning socket timeout for the scan roster.
+         *
+         * @param scanTimeout the value to set
+         * @return this builder
+         */
+        public Builder scanTimeout(Double scanTimeout) {
+            this.scanTimeout = Optional.of(scanTimeout);
+            return this;
+        }
+
+        /**
          * Run command via sudo.
          *
-         * @param sudo the value
+         * @param sudo the value to set
          * @return this builder
          */
         public Builder sudo(boolean sudo) {
             this.sudo = Optional.of(sudo);
+            return this;
+        }
+
+        /**
+         * Set the number of concurrent minions to communicate with. This value defines how
+         * many processes are opened up at a time to manage connections, the more running
+         * processes the faster communication should be. Default: 25.
+         *
+         * @param sshMaxProcs the value to set
+         * @return this builder
+         */
+        public Builder sshMaxProcs(int sshMaxProcs) {
+            this.sshMaxProcs = Optional.of(sshMaxProcs);
+            return this;
+        }
+
+        /**
+         * Set the default user to attempt to use when authenticating.
+         *
+         * @param user the value to set
+         * @return this builder
+         */
+        public Builder user(String user) {
+            this.user = Optional.of(user);
+            return this;
+        }
+
+        /**
+         * Remove the deployment of the salt files when done executing.
+         *
+         * @param wipe the value to set
+         * @return this builder
+         */
+        public Builder wipe(boolean wipe) {
+            this.wipe = Optional.of(wipe);
             return this;
         }
 

--- a/src/main/java/com/suse/salt/netapi/calls/SaltSSHConfig.java
+++ b/src/main/java/com/suse/salt/netapi/calls/SaltSSHConfig.java
@@ -13,7 +13,7 @@ public class SaltSSHConfig {
     private final Optional<Boolean> keyDeploy;
     private final Optional<Boolean> noHostKeys;
     private final Optional<String> passwd;
-    private final Optional<String> privateKeyFile;
+    private final Optional<String> priv;
     private final Optional<Boolean> rawShell;
     private final Optional<Boolean> refreshCache;
     private final Optional<String> remotePortForwards;
@@ -33,7 +33,7 @@ public class SaltSSHConfig {
         keyDeploy = builder.keyDeploy;
         noHostKeys = builder.noHostKeys;
         passwd = builder.passwd;
-        privateKeyFile = builder.privateKeyFile;
+        priv = builder.priv;
         rawShell = builder.rawShell;
         refreshCache = builder.refreshCache;
         remotePortForwards = builder.remotePortForwards;
@@ -71,8 +71,8 @@ public class SaltSSHConfig {
         return passwd;
     }
 
-    public Optional<String> getPrivateKeyFile() {
-        return privateKeyFile;
+    public Optional<String> getPriv() {
+        return priv;
     }
 
     public Optional<Boolean> getRawShell() {
@@ -130,7 +130,7 @@ public class SaltSSHConfig {
         private Optional<Boolean> keyDeploy = Optional.empty();
         private Optional<Boolean> noHostKeys = Optional.empty();
         private Optional<String> passwd = Optional.empty();
-        private Optional<String> privateKeyFile = Optional.empty();
+        private Optional<String> priv = Optional.empty();
         private Optional<Boolean> rawShell = Optional.empty();
         private Optional<Boolean> refreshCache = Optional.empty();
         private Optional<String> remotePortForwards = Optional.empty();
@@ -218,11 +218,11 @@ public class SaltSSHConfig {
         /**
          * SSH private key file.
          *
-         * @param privateKeyFile the value to set
+         * @param priv the value to set
          * @return this builder
          */
-        public Builder privateKeyFile(String privateKeyFile) {
-            this.rosterFile = Optional.of(privateKeyFile);
+        public Builder priv(String priv) {
+            this.priv = Optional.of(priv);
             return this;
         }
 

--- a/src/main/java/com/suse/salt/netapi/calls/SaltSSHConfig.java
+++ b/src/main/java/com/suse/salt/netapi/calls/SaltSSHConfig.java
@@ -1,0 +1,144 @@
+package com.suse.salt.netapi.calls;
+
+import java.util.Optional;
+
+/**
+ * Salt SSH configuration with a builder class.
+ */
+public class SaltSSHConfig {
+
+    private Optional<Boolean> ignoreHostKeys = Optional.empty();
+    private Optional<Boolean> noHostKeys = Optional.empty();
+    private Optional<String> privateKeyFile = Optional.empty();
+    private Optional<String> roster = Optional.empty();
+    private Optional<String> rosterFile = Optional.empty();
+    private Optional<Boolean> sudo = Optional.empty();
+
+    private SaltSSHConfig(Builder builder) {
+        ignoreHostKeys = builder.ignoreHostKeys;
+        noHostKeys = builder.noHostKeys;
+        privateKeyFile = builder.privateKeyFile;
+        roster = builder.roster;
+        rosterFile = builder.rosterFile;
+        sudo = builder.sudo;
+    }
+
+    public Optional<Boolean> getIgnoreHostKeys() {
+        return ignoreHostKeys;
+    }
+
+    public Optional<Boolean> getNoHostKeys() {
+        return noHostKeys;
+    }
+
+    public Optional<String> getPrivateKeyFile() {
+        return privateKeyFile;
+    }
+
+    public Optional<String> getRoster() {
+        return roster;
+    }
+
+    public Optional<String> getRosterFile() {
+        return rosterFile;
+    }
+
+    public Optional<Boolean> getSudo() {
+        return sudo;
+    }
+
+    /**
+     * Builder class to create configurations for Salt SSH.
+     */
+    public static class Builder {
+
+        private Optional<Boolean> ignoreHostKeys = Optional.empty();
+        private Optional<Boolean> noHostKeys = Optional.empty();
+        private Optional<String> privateKeyFile = Optional.empty();
+        private Optional<String> roster = Optional.empty();
+        private Optional<String> rosterFile = Optional.empty();
+        private Optional<Boolean> sudo = Optional.empty();
+
+        public Builder() {
+        }
+
+        /**
+         * By default ssh host keys are honored and connections will ask for approval. Use
+         * this option to disable 'StrictHostKeyChecking.'
+         *
+         * @param ignoreHostKeys the value
+         * @return this builder
+         */
+        public Builder ignoreHostKeys(boolean ignoreHostKeys) {
+            this.ignoreHostKeys = Optional.of(ignoreHostKeys);
+            return this;
+        }
+
+        /**
+         * Removes all host key checking functionality from SSH session.
+         *
+         * @param noHostKeys the value
+         * @return this builder
+         */
+        public Builder noHostKeys(boolean noHostKeys) {
+            this.noHostKeys = Optional.of(noHostKeys);
+            return this;
+        }
+
+        /**
+         * SSH private key file.
+         *
+         * @param privateKeyFile path to the file
+         * @return this builder
+         */
+        public Builder privateKeyFile(String privateKeyFile) {
+            this.rosterFile = Optional.of(privateKeyFile);
+            return this;
+        }
+
+        /**
+         * Define which roster system to use, this defines if a database backend, scanner,
+         * or custom roster system is used. Default: 'flat'.
+         *
+         * @param roster the roster system to use
+         * @return this builder
+         */
+        public Builder roster(String roster) {
+            this.roster = Optional.of(roster);
+            return this;
+        }
+
+        /**
+         * Define an alternative location for the default roster file location. The default
+         * roster file is called roster and is found in the same directory as the master
+         * config file.
+         *
+         * @param rosterFile the roster file location
+         * @return this builder
+         */
+        public Builder rosterFile(String rosterFile) {
+            this.rosterFile = Optional.of(rosterFile);
+            return this;
+        }
+
+        /**
+         * Run command via sudo.
+         *
+         * @param sudo the value
+         * @return this builder
+         */
+        public Builder sudo(boolean sudo) {
+            this.sudo = Optional.of(sudo);
+            return this;
+        }
+
+        /**
+         * Build the configuration object.
+         *
+         * @return the config object
+         */
+        public SaltSSHConfig build() {
+            return new SaltSSHConfig(this);
+        }
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/calls/SaltSSHConfig.java
+++ b/src/main/java/com/suse/salt/netapi/calls/SaltSSHConfig.java
@@ -7,12 +7,12 @@ import java.util.Optional;
  */
 public class SaltSSHConfig {
 
-    private Optional<Boolean> ignoreHostKeys = Optional.empty();
-    private Optional<Boolean> noHostKeys = Optional.empty();
-    private Optional<String> privateKeyFile = Optional.empty();
-    private Optional<String> roster = Optional.empty();
-    private Optional<String> rosterFile = Optional.empty();
-    private Optional<Boolean> sudo = Optional.empty();
+    private final Optional<Boolean> ignoreHostKeys;
+    private final Optional<Boolean> noHostKeys;
+    private final Optional<String> privateKeyFile;
+    private final Optional<String> roster;
+    private final Optional<String> rosterFile;
+    private final Optional<Boolean> sudo;
 
     private SaltSSHConfig(Builder builder) {
         ignoreHostKeys = builder.ignoreHostKeys;

--- a/src/main/java/com/suse/salt/netapi/calls/modules/State.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/State.java
@@ -1,7 +1,10 @@
 package com.suse.salt.netapi.calls.modules;
 
 import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.parser.JsonParser;
+import com.suse.salt.netapi.results.StateApplyResult;
 
+import com.google.gson.JsonElement;
 import com.google.gson.reflect.TypeToken;
 
 import java.util.Arrays;
@@ -15,24 +18,38 @@ import java.util.Optional;
  */
 public class State {
 
+    /**
+     * Result type for state.apply
+     */
+    public static class ApplyResult extends StateApplyResult<JsonElement> {
+
+        public <R> R getChanges(Class<R> dataType) {
+            return JsonParser.GSON.fromJson(changes, dataType);
+        }
+
+        public <R> R getChanges(TypeToken<R> dataType) {
+            return JsonParser.GSON.fromJson(changes, dataType.getType());
+        }
+    }
+
     private State() { }
 
-    public static LocalCall<Map<String, Object>> apply(List<String> mods) {
+    public static LocalCall<Map<String, ApplyResult>> apply(List<String> mods) {
         return apply(mods, Optional.empty(), Optional.empty());
     }
 
-    public static LocalCall<Map<String, Object>> apply(String... mods) {
+    public static LocalCall<Map<String, ApplyResult>> apply(String... mods) {
         return apply(Arrays.asList(mods), Optional.empty(), Optional.empty());
     }
 
-    public static LocalCall<Map<String, Object>> apply(List<String> mods,
+    public static LocalCall<Map<String, ApplyResult>> apply(List<String> mods,
             Optional<Map<String, Object>> pillar, Optional<Boolean> queue) {
         Map<String, Object> kwargs = new LinkedHashMap<>();
         kwargs.put("mods", mods);
         pillar.ifPresent(p -> kwargs.put("pillar", p));
         queue.ifPresent(q -> kwargs.put("queue", q));
         return new LocalCall<>("state.apply", Optional.empty(), Optional.of(kwargs),
-                new TypeToken<Map<String, Object>>(){});
+                new TypeToken<Map<String, ApplyResult>>(){});
     }
 
     public static LocalCall<Object> showHighstate() {

--- a/src/main/java/com/suse/salt/netapi/results/SSHResult.java
+++ b/src/main/java/com/suse/salt/netapi/results/SSHResult.java
@@ -1,0 +1,46 @@
+package com.suse.salt.netapi.results;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * Wrapper class for salt-ssh results.
+ *
+ * @param <T> The type of the value this result holds.
+ */
+public class SSHResult<T> {
+
+    private String fun;
+    @SerializedName("fun_args")
+    private List<String> funArgs;
+    private String id;
+    private String jid;
+    private int retcode;
+    @SerializedName("return")
+    private T returnAttribute;
+
+    public String getFun() {
+        return fun;
+    }
+
+    public List<String> getFunArgs() {
+        return funArgs;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getJid() {
+        return jid;
+    }
+
+    public int getRetcode() {
+        return retcode;
+    }
+
+    public T getReturn() {
+        return returnAttribute;
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/results/SSHResult.java
+++ b/src/main/java/com/suse/salt/netapi/results/SSHResult.java
@@ -20,6 +20,8 @@ public class SSHResult<T> {
     private int retcode;
     @SerializedName("return")
     private Optional<T> returnAttribute = Optional.empty();
+    private Optional<String> stderr = Optional.empty();
+    private Optional<String> stdout = Optional.empty();
 
     public String getFun() {
         return fun;
@@ -43,5 +45,13 @@ public class SSHResult<T> {
 
     public Optional<T> getReturn() {
         return returnAttribute;
+    }
+
+    public Optional<String> getStderr() {
+        return stderr;
+    }
+
+    public Optional<String> getStdout() {
+        return stdout;
     }
 }

--- a/src/main/java/com/suse/salt/netapi/results/SSHResult.java
+++ b/src/main/java/com/suse/salt/netapi/results/SSHResult.java
@@ -3,6 +3,7 @@ package com.suse.salt.netapi.results;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Wrapper class for salt-ssh results.
@@ -18,7 +19,7 @@ public class SSHResult<T> {
     private String jid;
     private int retcode;
     @SerializedName("return")
-    private T returnAttribute;
+    private Optional<T> returnAttribute = Optional.empty();
 
     public String getFun() {
         return fun;
@@ -40,7 +41,7 @@ public class SSHResult<T> {
         return retcode;
     }
 
-    public T getReturn() {
+    public Optional<T> getReturn() {
         return returnAttribute;
     }
 }

--- a/src/main/java/com/suse/salt/netapi/results/StateApplyResult.java
+++ b/src/main/java/com/suse/salt/netapi/results/StateApplyResult.java
@@ -17,7 +17,7 @@ public class StateApplyResult<R> {
     private double duration;
     @SerializedName("__run_num__")
     private int runNum;
-    private R changes;
+    protected R changes;
 
     public String getComment() {
         return comment;

--- a/src/test/java/com/suse/salt/netapi/calls/LocalCallTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/LocalCallTest.java
@@ -1,16 +1,61 @@
 package com.suse.salt.netapi.calls;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import com.suse.salt.netapi.calls.modules.Cmd;
+import com.suse.salt.netapi.client.SaltClient;
+import com.suse.salt.netapi.client.SaltClientTest;
+import com.suse.salt.netapi.datatypes.target.Glob;
+import com.suse.salt.netapi.datatypes.target.Target;
+import com.suse.salt.netapi.exception.SaltException;
+import com.suse.salt.netapi.results.Result;
+import com.suse.salt.netapi.results.SSHResult;
+import com.suse.salt.netapi.utils.ClientUtils;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * Tests for LocalCall
  */
 public class LocalCallTest {
+
+    private static final int MOCK_HTTP_PORT = 8888;
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(MOCK_HTTP_PORT);
+
+    static final String JSON_SSH_PING_REQUEST = ClientUtils.streamToString(
+            SaltClientTest.class.getResourceAsStream("/ssh_ping_request.json"));
+    static final String JSON_SSH_PING_RESPONSE = ClientUtils.streamToString(
+            SaltClientTest.class.getResourceAsStream("/ssh_ping_response.json"));
+
+    private SaltClient client;
+
+    @Before
+    public void init() {
+        URI uri = URI.create("http://localhost:" + Integer.toString(MOCK_HTTP_PORT));
+        client = new SaltClient(uri);
+    }
 
     @Test
     public void testWithMetadata() {
@@ -28,4 +73,37 @@ public class LocalCallTest {
         assertEquals(runWithMetadata.getPayload().get("metadata"), "myMetadata");
     }
 
+    @Test
+    public void testCallSyncSSH() throws SaltException {
+        stubFor(any(urlMatching(".*"))
+                .willReturn(aResponse()
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_SSH_PING_RESPONSE)));
+
+        LocalCall<Boolean> run = com.suse.salt.netapi.calls.modules.Test.ping();
+        SaltSSHConfig config = new SaltSSHConfig.Builder()
+                .rosterFile("/tmp/my-roster")
+                .ignoreHostKeys(true)
+                .build();
+        Target<String> target = new Glob("*");
+        Map<String, Result<SSHResult<Boolean>>> result =
+                run.callSyncSSH(client, target, config);
+
+        // Verify the request
+        verify(1, postRequestedFor(urlEqualTo("/run"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withHeader("Content-Type", equalTo("application/json"))
+                .withRequestBody(equalToJson(JSON_SSH_PING_REQUEST)));
+
+        // Verify the result
+        assertEquals("test.ping", result.get("my.minion").result().get().getFun());
+        assertEquals(Collections.EMPTY_LIST,
+                result.get("my.minion").result().get().getFunArgs());
+        assertEquals("my.minion", result.get("my.minion").result().get().getId());
+        assertEquals("20160701150655664384",
+                result.get("my.minion").result().get().getJid());
+        assertEquals(0, result.get("my.minion").result().get().getRetcode());
+        assertTrue(result.get("my.minion").result().get().getReturn().get());
+    }
 }

--- a/src/test/java/com/suse/salt/netapi/examples/SaltSSH.java
+++ b/src/test/java/com/suse/salt/netapi/examples/SaltSSH.java
@@ -1,0 +1,63 @@
+package com.suse.salt.netapi.examples;
+
+import com.suse.salt.netapi.calls.modules.Grains;
+import com.suse.salt.netapi.calls.modules.Test;
+import com.suse.salt.netapi.client.SaltClient;
+import com.suse.salt.netapi.datatypes.target.Glob;
+import com.suse.salt.netapi.datatypes.target.MinionList;
+import com.suse.salt.netapi.datatypes.target.Target;
+import com.suse.salt.netapi.exception.SaltException;
+import com.suse.salt.netapi.results.Result;
+import com.suse.salt.netapi.results.SSHResult;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Example code calling salt modules via ssh.
+ */
+public class SaltSSH {
+
+    private static final String SALT_API_URL = "http://localhost:8000";
+
+    public static void main(String[] args) throws SaltException {
+        // Init the client
+        SaltClient client = new SaltClient(URI.create(SALT_API_URL));
+
+        // Ping all minions using a glob matcher
+        Target<String> globTarget = new Glob("*");
+        Map<String, Result<SSHResult<Boolean>>> minionResults = Test.ping().callSyncSSH(
+                client, globTarget, Optional.of("/tmp/susemanager-roster"));
+
+        System.out.println("--> Ping results:\n");
+        minionResults.forEach((minion, result) -> {
+            System.out.println(minion + " -> " + result.fold(
+                    error -> "Error: " + error.toString()
+                    ,
+                    res -> res.getReturn().orElse(false)
+            ));
+        });
+
+        // Get grains from a list of minions
+        Target<List<String>> minionList = new MinionList("my.future.minion");
+        Map<String, Result<SSHResult<Map<String, Object>>>> grainResults = Grains.
+                items(false).callSyncSSH(client, minionList, Optional.of("/tmp/my-roster"));
+
+        grainResults.forEach((minion, grains) -> {
+            System.out.println("\n--> Listing grains for '" + minion + "':\n");
+            String grainsOutput = grains.fold(
+                    error -> "Error: " + error.toString(),
+                    grainsMap -> {
+                            grainsMap.getReturn().ifPresent(gmap -> gmap.entrySet().stream()
+                                    .map(e -> e.getKey() + ": " + e.getValue())
+                                    .collect(Collectors.joining("\n")));
+                            return "Minion did not return: " + minion;
+                    }
+            );
+            System.out.println(grainsOutput);
+        });
+    }
+}

--- a/src/test/java/com/suse/salt/netapi/examples/SaltSSH.java
+++ b/src/test/java/com/suse/salt/netapi/examples/SaltSSH.java
@@ -49,12 +49,11 @@ public class SaltSSH {
             System.out.println("\n--> Listing grains for '" + minion + "':\n");
             String grainsOutput = grains.fold(
                     error -> "Error: " + error.toString(),
-                    grainsMap -> {
-                            grainsMap.getReturn().ifPresent(gmap -> gmap.entrySet().stream()
+                    grainsMap -> grainsMap.getReturn()
+                            .map(g -> g.entrySet().stream()
                                     .map(e -> e.getKey() + ": " + e.getValue())
-                                    .collect(Collectors.joining("\n")));
-                            return "Minion did not return: " + minion;
-                    }
+                                    .collect(Collectors.joining("\n")))
+                            .orElse("Minion did not return: " + minion)
             );
             System.out.println(grainsOutput);
         });

--- a/src/test/java/com/suse/salt/netapi/examples/SaltSSH.java
+++ b/src/test/java/com/suse/salt/netapi/examples/SaltSSH.java
@@ -1,5 +1,6 @@
 package com.suse.salt.netapi.examples;
 
+import com.suse.salt.netapi.calls.SaltSSHConfig;
 import com.suse.salt.netapi.calls.modules.Grains;
 import com.suse.salt.netapi.calls.modules.Test;
 import com.suse.salt.netapi.client.SaltClient;
@@ -24,10 +25,13 @@ public class SaltSSH {
         // Init the client
         SaltClient client = new SaltClient(URI.create(SALT_API_URL));
 
+        // Setup the configuration for Salt SSH (use defaults)
+        SaltSSHConfig sshConfig = new SaltSSHConfig.Builder().build();
+
         // Ping all minions using a glob matcher
         Target<String> globTarget = new Glob("*");
         Map<String, Result<SSHResult<Boolean>>> minionResults =
-                Test.ping().callSyncSSH(client, globTarget);
+                Test.ping().callSyncSSH(client, globTarget, sshConfig);
 
         System.out.println("--> Ping results:\n");
         minionResults.forEach((minion, result) -> {
@@ -39,7 +43,7 @@ public class SaltSSH {
 
         // Get grains from all minions
         Map<String, Result<SSHResult<Map<String, Object>>>> grainResults =
-                Grains.items(false).callSyncSSH(client, globTarget);
+                Grains.items(false).callSyncSSH(client, globTarget, sshConfig);
 
         grainResults.forEach((minion, grains) -> {
             System.out.println("\n--> Listing grains for '" + minion + "':\n");

--- a/src/test/java/com/suse/salt/netapi/examples/SaltSSH.java
+++ b/src/test/java/com/suse/salt/netapi/examples/SaltSSH.java
@@ -4,16 +4,13 @@ import com.suse.salt.netapi.calls.modules.Grains;
 import com.suse.salt.netapi.calls.modules.Test;
 import com.suse.salt.netapi.client.SaltClient;
 import com.suse.salt.netapi.datatypes.target.Glob;
-import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.salt.netapi.datatypes.target.Target;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.results.SSHResult;
 
 import java.net.URI;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -29,22 +26,20 @@ public class SaltSSH {
 
         // Ping all minions using a glob matcher
         Target<String> globTarget = new Glob("*");
-        Map<String, Result<SSHResult<Boolean>>> minionResults = Test.ping().callSyncSSH(
-                client, globTarget, Optional.of("/tmp/susemanager-roster"));
+        Map<String, Result<SSHResult<Boolean>>> minionResults =
+                Test.ping().callSyncSSH(client, globTarget);
 
         System.out.println("--> Ping results:\n");
         minionResults.forEach((minion, result) -> {
             System.out.println(minion + " -> " + result.fold(
-                    error -> "Error: " + error.toString()
-                    ,
+                    error -> "Error: " + error.toString(),
                     res -> res.getReturn().orElse(false)
             ));
         });
 
-        // Get grains from a list of minions
-        Target<List<String>> minionList = new MinionList("my.future.minion");
-        Map<String, Result<SSHResult<Map<String, Object>>>> grainResults = Grains.
-                items(false).callSyncSSH(client, minionList, Optional.of("/tmp/my-roster"));
+        // Get grains from all minions
+        Map<String, Result<SSHResult<Map<String, Object>>>> grainResults =
+                Grains.items(false).callSyncSSH(client, globTarget);
 
         grainResults.forEach((minion, grains) -> {
             System.out.println("\n--> Listing grains for '" + minion + "':\n");

--- a/src/test/resources/ssh_ping_request.json
+++ b/src/test/resources/ssh_ping_request.json
@@ -4,7 +4,20 @@
     "tgt": "*",
     "client": "ssh",
     "fun": "test.ping",
+    "extra_filerefs": "my/file/ref",
+    "ignore_host_keys": true,
+    "no_host_keys": true,
+    "refresh_cache": true,
+    "roster": "flat",
     "roster_file": "/tmp/my-roster",
-    "ignore_host_keys": true
+    "ssh_identities_only": true,
+    "ssh_key_deploy": true,
+    "ssh_max_procs": 50,
+    "ssh_passwd": "pa55wd",
+    "ssh_priv": "/home/user/.ssh/id_rsa",
+    "ssh_remote_port_forwards": "8888:my.host:443",
+    "ssh_sudo": true,
+    "ssh_user": "user",
+    "ssh_wipe": true
   }
 ]

--- a/src/test/resources/ssh_ping_request.json
+++ b/src/test/resources/ssh_ping_request.json
@@ -1,0 +1,10 @@
+[
+  {
+    "expr_form": "glob",
+    "tgt": "*",
+    "client": "ssh",
+    "fun": "test.ping",
+    "roster_file": "/tmp/my-roster",
+    "ignore_host_keys": true
+  }
+]

--- a/src/test/resources/ssh_ping_response.json
+++ b/src/test/resources/ssh_ping_response.json
@@ -1,0 +1,12 @@
+{
+  "return": [{
+    "my.minion": {
+      "fun_args": [],
+      "jid": "20160701150655664384",
+      "return": true,
+      "retcode": 0,
+      "fun": "test.ping",
+      "id": "my.minion"
+    }
+  }]
+}


### PR DESCRIPTION
This patch adds support for calling `LocalCall` instances synchronously via `salt-ssh`. The results of calls to `state.apply` were further refined to be parsed into the new type `State.ApplyResult` that contains the changes unparsed as `JSONElement`.