### PR TITLE
Change type of `registerrelease`

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/modules/Zypper.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/Zypper.java
@@ -29,7 +29,7 @@ public class Zypper {
         private final boolean installed;
         private final boolean isbase;
         private final String productline;
-        private final String registerrelease;
+        private final boolean registerrelease;
         private final String release;
         private final String repo;
         private final String shortname;
@@ -39,7 +39,7 @@ public class Zypper {
 
         public ProductInfo(String name, String arch, String description, String eol,
                 String epoch, String flavor, boolean installed, boolean isbase,
-                String productline, String registerrelease, String release, String repo,
+                String productline, boolean registerrelease, String release, String repo,
                 String shortname, String summary, String vendor, String version) {
             this.name = name;
             this.arch = arch;
@@ -99,7 +99,7 @@ public class Zypper {
             return productline;
         }
 
-        public String getRegisterrelease() {
+        public boolean getRegisterrelease() {
             return registerrelease;
         }
 


### PR DESCRIPTION
Using salt 2015.8.7 (Beryllium), field `registerrelease` is marked as boolean.

Example:
2016-07-15 14:03:04,511 [RHN Message Dispatcher] WARN  com.suse.manager.webui.services.impl.SaltAPIService - GenericSaltError([{"eol_t":1730332800,"productline":"sles","name":"SLES","installed":true,"vendor":"SUSE","summary":"SUSE Linux Enterprise Server 12 SP1","repo":"@System","registerrelease":false,"epoch":"0","version":"12.1","release":"0","isbase":true,"flavor":"DVD","eol":"2024-10-31T00:00:00+00","arch":"x86_64","shortname":"SLES12-SP1","description":"SUSE Linux Enterprise offers a comprehensive suite of products built on a single code base. The platform addresses business needs from the smallest thin-client devices to the world's most powerful high-performance computing and mainframe servers. SUSE Linux Enterprise offers common management tools and technology certifications across the platform, and each product is enterprise-class."}], java.lang.IllegalStateException: Expected STRING but was BOOLEAN)