### PR TITLE
Added local_batch support with tests.

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/Client.java
+++ b/src/main/java/com/suse/salt/netapi/calls/Client.java
@@ -6,6 +6,7 @@ package com.suse.salt.netapi.calls;
 public enum Client {
 
     LOCAL("local"),
+    LOCAL_BATCH("local_batch"),
     LOCAL_ASYNC("local_async"),
     WHEEL("wheel"),
     WHEEL_ASYNC("wheel_async"),

--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -143,22 +143,8 @@ public class LocalCall<R> implements Call<R> {
      */
     public Map<String, Result<R>> callSync(final SaltClient client, Target<?> target)
             throws SaltException {
-        Map<String, Object> customArgs = new HashMap<>();
-        customArgs.put("tgt", target.getTarget());
-        customArgs.put("expr_form", target.getType());
-
-        Type xor = parameterizedType(null, Result.class, getReturnType().getType());
-        Type map = parameterizedType(null, Map.class, String.class, xor);
-        Type listType = parameterizedType(null, List.class, map);
-        Type wrapperType = parameterizedType(null, Return.class, listType);
-
-        @SuppressWarnings("unchecked")
-        Return<List<Map<String, Result<R>>>> wrapper = client.call(this,
-                Client.LOCAL, "/",
-                Optional.of(customArgs),
-                (TypeToken<Return<List<Map<String, Result<R>>>>>)
-                TypeToken.get(wrapperType));
-        return wrapper.getResult().get(0);
+        return callSyncBatchable(client, target, Optional.empty(),
+                Optional.empty(), Optional.empty(), Optional.empty()).get(0);
     }
 
     /**
@@ -178,13 +164,85 @@ public class LocalCall<R> implements Call<R> {
             final SaltClient client, Target<?> target,
             String username, String password, AuthModule authModule)
             throws SaltException {
+        return callSyncBatchable(client, target, Optional.of(username),
+                Optional.of(password), Optional.of(authModule), Optional.empty()).get(0);
+    }
+
+    /**
+     * Calls a execution module function on the given target with batching and
+     * synchronously waits for the result. Authentication is done with the token
+     * therefore you have to login prior to using this function.
+     *
+     * @param client SaltClient instance
+     * @param target the target for the function
+     * @param batch  the batch parameter, e.g. 10, 10%, etc.
+     * @return A list of maps with each list representing each batch, and maps containing
+     * the results with the minion names as keys.
+     * @throws SaltException if anything goes wrong
+     */
+    public List<Map<String, Result<R>>> callSyncBatch(
+            final SaltClient client, Target<?> target, String batch)
+            throws SaltException {
+        return callSyncBatchable(client, target, Optional.empty(),
+                Optional.empty(), Optional.empty(), Optional.of(batch));
+    }
+
+    /**
+     * Calls a execution module function on the given target with batching and
+     * synchronously waits for the result. Authentication is done with the given
+     * credentials no session token is created.
+     *
+     * @param client SaltClient instance
+     * @param target the target for the function
+     * @param username username for authentication
+     * @param password password for authentication
+     * @param authModule authentication module to use
+     * @param batch the batch parameter, e.g. 10, 10%, etc.
+     * @return A list of maps with each list representing each batch, and maps containing
+     * the results with the minion names as keys.
+     * @throws SaltException if anything goes wrong
+     */
+    public List<Map<String, Result<R>>> callSyncBatch(
+            final SaltClient client, Target<?> target,
+            String username, String password, AuthModule authModule, String batch)
+            throws SaltException {
+        return callSyncBatchable(client, target, Optional.of(username),
+                Optional.of(password), Optional.of(authModule), Optional.of(batch));
+    }
+
+    /**
+     * Calls a execution module function on the given target for batched or unbatched
+     * input, and provides option to use given credentials or to use a prior created
+     * token. Synchronously waits for the result.
+     *
+     * @param client SaltClient instance
+     * @param target the target for the function
+     * @param username username for authentication, empty for token auth
+     * @param password password for authentication, empty for token auth
+     * @param authModule authentication module to use, empty for token auth
+     * @param batch the batch parameter, e.g. 10, 10%, etc., empty for unbatched
+     * @return A list of maps with each list representing each batch, and maps containing
+     * the results with the minion names as keys. The first list is the entire
+     * output for unbatched input.
+     * @throws SaltException
+     */
+    private List<Map<String, Result<R>>> callSyncBatchable(
+            final SaltClient client, Target<?> target,
+            Optional<String> username, Optional<String> password,
+            Optional<AuthModule> authModule, Optional<String> batch)
+            throws SaltException {
         Map<String, Object> customArgs = new HashMap<>();
         customArgs.putAll(getPayload());
-        customArgs.put("username", username);
-        customArgs.put("password", password);
-        customArgs.put("eauth", authModule.getValue());
         customArgs.put("tgt", target.getTarget());
         customArgs.put("expr_form", target.getType());
+        username.ifPresent(v -> customArgs.put("username", v));
+        password.ifPresent(v -> customArgs.put("password", v));
+        authModule.ifPresent(v -> customArgs.put("eauth", v.getValue()));
+        batch.ifPresent(v -> customArgs.put("batch", v));
+
+        Client clientType = batch.isPresent() ? Client.LOCAL_BATCH : Client.LOCAL;
+        // We need a different endpoint for credentials vs token auth
+        String endPoint = username.isPresent() ? "/run" : "/";
 
         Type xor = parameterizedType(null, Result.class, getReturnType().getType());
         Type map = parameterizedType(null, Map.class, String.class, xor);
@@ -193,11 +251,11 @@ public class LocalCall<R> implements Call<R> {
 
         @SuppressWarnings("unchecked")
         Return<List<Map<String, Result<R>>>> wrapper = client.call(this,
-                Client.LOCAL, "/run",
+                clientType, endPoint,
                 Optional.of(customArgs),
                 (TypeToken<Return<List<Map<String, Result<R>>>>>)
                 TypeToken.get(wrapperType));
-        return wrapper.getResult().get(0);
+        return wrapper.getResult();
     }
 
     /**

--- a/src/main/java/com/suse/salt/netapi/datatypes/Batch.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/Batch.java
@@ -1,0 +1,48 @@
+package com.suse.salt.netapi.datatypes;
+
+/**
+ * A class representing the batch parameter. Salt uses a string for the batch parameter,
+ * but it accept strings representing both exact numerals and percents, so this class
+ * encapsulates the creation and usage of the batch strings, adding safety.
+ */
+public class Batch {
+    // The actual batch string
+    private String batch;
+
+    private Batch(String batch) {
+        this.batch = batch;
+    }
+
+    @Override
+    public String toString() {
+        return batch;
+    }
+
+    /**
+     * Construct a Batch from a value representing a percent
+     * @param value the percent, which must be greater than 0 and less than or equal to 100
+     * @return the Batch
+     */
+    public static Batch asPercent(int value) {
+        if (value <= 0 || value > 100) {
+            throw new IllegalArgumentException("Expected value greater than 0 and less " +
+                    "than or equal to 100 to make valid batch as a percent.");
+        }
+
+        return new Batch(Integer.toString(value) + "%");
+    }
+
+    /**
+     * Construct a Batch from a value representing an exact amount of items
+     * @param value the exact amount of items, which must be greater than 0
+     * @return the Batch
+     */
+    public static Batch asAmount(int value) {
+        if (value <= 0) {
+            throw new IllegalArgumentException("Expected value greater than 0 to make a " +
+                    "valid batch amount");
+        }
+
+        return new Batch(Integer.toString(value));
+    }
+}

--- a/src/test/java/com/suse/salt/netapi/calls/LocalCallTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/LocalCallTest.java
@@ -1,5 +1,18 @@
 package com.suse.salt.netapi.calls;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import com.suse.salt.netapi.AuthModule;
 import com.suse.salt.netapi.calls.modules.Cmd;
 import com.suse.salt.netapi.client.SaltClient;
@@ -17,9 +30,6 @@ import org.junit.Test;
 
 import java.net.HttpURLConnection;
 import java.net.URI;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.junit.Assert.*;
 
 /**
  * Tests for LocalCall
@@ -42,7 +52,8 @@ public class LocalCallTest {
     static final String JSON_CALL_SYNC_BATCH_PING_REQUEST = ClientUtils.streamToString(
             SaltClientTest.class.getResourceAsStream("/call_sync_batch_ping_request.json"));
     static final String JSON_CALL_SYNC_BATCH_PING_RESPONSE = ClientUtils.streamToString(
-            SaltClientTest.class.getResourceAsStream("/call_sync_batch_ping_response.json"));
+            SaltClientTest.class.getResourceAsStream(
+                    "/call_sync_batch_ping_response.json"));
 
     private SaltClient client;
 

--- a/src/test/java/com/suse/salt/netapi/calls/LocalCallTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/LocalCallTest.java
@@ -17,6 +17,7 @@ import com.suse.salt.netapi.AuthModule;
 import com.suse.salt.netapi.calls.modules.Cmd;
 import com.suse.salt.netapi.client.SaltClient;
 import com.suse.salt.netapi.client.SaltClientTest;
+import com.suse.salt.netapi.datatypes.Batch;
 import com.suse.salt.netapi.datatypes.target.Glob;
 import com.suse.salt.netapi.datatypes.target.Target;
 import com.suse.salt.netapi.exception.SaltException;
@@ -104,7 +105,7 @@ public class LocalCallTest {
      * Verify correctness of the request body with an exemplary synchronous batch call.
      */
     @Test
-    public void testCallSyncBatch() throws SaltException {
+    public void testCallSyncWithBatch() throws SaltException {
         stubFor(any(urlMatching("/run"))
                 .willReturn(aResponse()
                 .withStatus(HttpURLConnection.HTTP_OK)
@@ -114,7 +115,7 @@ public class LocalCallTest {
         LocalCall<Boolean> run = com.suse.salt.netapi.calls.modules.Test.ping();
         Target<String> target = new Glob("*");
 
-        run.callSyncBatch(client, target, "user", "pa55wd", AuthModule.AUTO, "1");
+        run.callSync(client, target, "user", "pa55wd", AuthModule.AUTO, Batch.asAmount(1));
         verify(1, postRequestedFor(urlEqualTo("/run"))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Content-Type", equalTo("application/json"))

--- a/src/test/java/com/suse/salt/netapi/calls/LocalCallTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/LocalCallTest.java
@@ -1,18 +1,6 @@
 package com.suse.salt.netapi.calls;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.any;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
-import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
+import com.suse.salt.netapi.AuthModule;
 import com.suse.salt.netapi.calls.modules.Cmd;
 import com.suse.salt.netapi.client.SaltClient;
 import com.suse.salt.netapi.client.SaltClientTest;
@@ -30,6 +18,9 @@ import org.junit.Test;
 import java.net.HttpURLConnection;
 import java.net.URI;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.Assert.*;
+
 /**
  * Tests for LocalCall
  */
@@ -44,6 +35,14 @@ public class LocalCallTest {
             SaltClientTest.class.getResourceAsStream("/ssh_ping_request.json"));
     static final String JSON_SSH_PING_RESPONSE = ClientUtils.streamToString(
             SaltClientTest.class.getResourceAsStream("/ssh_ping_response.json"));
+    static final String JSON_CALL_SYNC_PING_REQUEST = ClientUtils.streamToString(
+            SaltClientTest.class.getResourceAsStream("/call_sync_ping_request.json"));
+    static final String JSON_CALL_SYNC_PING_RESPONSE = ClientUtils.streamToString(
+            SaltClientTest.class.getResourceAsStream("/call_sync_ping_response.json"));
+    static final String JSON_CALL_SYNC_BATCH_PING_REQUEST = ClientUtils.streamToString(
+            SaltClientTest.class.getResourceAsStream("/call_sync_batch_ping_request.json"));
+    static final String JSON_CALL_SYNC_BATCH_PING_RESPONSE = ClientUtils.streamToString(
+            SaltClientTest.class.getResourceAsStream("/call_sync_batch_ping_response.json"));
 
     private SaltClient client;
 
@@ -67,6 +66,48 @@ public class LocalCallTest {
         assertFalse(runWithoutMetadata.getPayload().containsKey("metadata"));
         assertTrue(runWithMetadata.getPayload().containsKey("metadata"));
         assertEquals(runWithMetadata.getPayload().get("metadata"), "myMetadata");
+    }
+
+    /**
+     * Verify correctness of the request body with an exemplary synchronous call.
+     */
+    @Test
+    public void testCallSync() throws SaltException {
+        stubFor(any(urlMatching("/run"))
+                .willReturn(aResponse()
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_CALL_SYNC_PING_RESPONSE)));
+
+        LocalCall<Boolean> run = com.suse.salt.netapi.calls.modules.Test.ping();
+        Target<String> target = new Glob("*");
+
+        run.callSync(client, target, "user", "pa55wd", AuthModule.AUTO);
+        verify(1, postRequestedFor(urlEqualTo("/run"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withHeader("Content-Type", equalTo("application/json"))
+                .withRequestBody(equalToJson(JSON_CALL_SYNC_PING_REQUEST)));
+    }
+
+    /**
+     * Verify correctness of the request body with an exemplary synchronous batch call.
+     */
+    @Test
+    public void testCallSyncBatch() throws SaltException {
+        stubFor(any(urlMatching("/run"))
+                .willReturn(aResponse()
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_CALL_SYNC_BATCH_PING_RESPONSE)));
+
+        LocalCall<Boolean> run = com.suse.salt.netapi.calls.modules.Test.ping();
+        Target<String> target = new Glob("*");
+
+        run.callSyncBatch(client, target, "user", "pa55wd", AuthModule.AUTO, "1");
+        verify(1, postRequestedFor(urlEqualTo("/run"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withHeader("Content-Type", equalTo("application/json"))
+                .withRequestBody(equalToJson(JSON_CALL_SYNC_BATCH_PING_REQUEST)));
     }
 
     /**

--- a/src/test/java/com/suse/salt/netapi/datatypes/BatchTest.java
+++ b/src/test/java/com/suse/salt/netapi/datatypes/BatchTest.java
@@ -1,0 +1,24 @@
+package com.suse.salt.netapi.datatypes;
+
+import org.junit.Test;
+
+/**
+ * Test the verification of numeric batch re
+ */
+public class BatchTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void percentGreaterThan100ShouldThrowException() {
+        Batch.asPercent(101);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void percentEqualToZeroShouldThrowException() {
+        Batch.asPercent(0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void amountEqualToZeroShouldThrowException() {
+        Batch.asAmount(0);
+    }
+}

--- a/src/test/resources/call_sync_batch_ping_request.json
+++ b/src/test/resources/call_sync_batch_ping_request.json
@@ -1,0 +1,12 @@
+[
+  {
+    "tgt": "*",
+    "eauth": "auto",
+    "password": "pa55wd",
+    "expr_form": "glob",
+    "batch": "1",
+    "client": "local_batch",
+    "fun": "test.ping",
+    "username": "user"
+  }
+]

--- a/src/test/resources/call_sync_batch_ping_response.json
+++ b/src/test/resources/call_sync_batch_ping_response.json
@@ -1,0 +1,10 @@
+{
+  "return": [
+    {
+      "minion2": true
+    },
+    {
+      "minion1": true
+    }
+  ]
+}

--- a/src/test/resources/call_sync_ping_request.json
+++ b/src/test/resources/call_sync_ping_request.json
@@ -1,0 +1,11 @@
+[
+  {
+    "tgt": "*",
+    "eauth": "auto",
+    "password": "pa55wd",
+    "expr_form": "glob",
+    "client": "local",
+    "fun": "test.ping",
+    "username": "user"
+  }
+]

--- a/src/test/resources/call_sync_ping_response.json
+++ b/src/test/resources/call_sync_ping_response.json
@@ -1,0 +1,8 @@
+{
+  "return": [
+    {
+      "minion1": true,
+      "minion2": true
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #84 

Refactored some code in LocalCall because callSync and callSyncBatch
used nearly the same logic. They now both use a helper function called
callSyncBatchable.

Added a test for callSyncBatch that checks the request body. Also added
a test for callSync that checks the request body to ensure it is not
accidentally using batching when calling callSyncBatchable.