### PR TITLE
Add support for `raw_shell` commands via salt-ssh

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -276,24 +276,7 @@ public class LocalCall<R> implements Call<R> {
         args.put("tgt", target.getTarget());
         args.put("expr_form", target.getType());
 
-        // Map config properties to arguments
-        cfg.getExtraFilerefs().ifPresent(v -> args.put("extra_filerefs", v));
-        cfg.getIdentitiesOnly().ifPresent(v -> args.put("ssh_identities_only", v));
-        cfg.getIgnoreHostKeys().ifPresent(v -> args.put("ignore_host_keys", v));
-        cfg.getKeyDeploy().ifPresent(v -> args.put("ssh_key_deploy", v));
-        cfg.getNoHostKeys().ifPresent(v -> args.put("no_host_keys", v));
-        cfg.getPasswd().ifPresent(v -> args.put("ssh_passwd", v));
-        cfg.getPriv().ifPresent(v -> args.put("ssh_priv", v));
-        cfg.getRefreshCache().ifPresent(v -> args.put("refresh_cache", v));
-        cfg.getRemotePortForwards().ifPresent(v -> args.put("ssh_remote_port_forwards", v));
-        cfg.getRoster().ifPresent(v -> args.put("roster", v));
-        cfg.getRosterFile().ifPresent(v -> args.put("roster_file", v));
-        cfg.getScanPorts().ifPresent(v -> args.put("ssh_scan_ports", v));
-        cfg.getScanTimeout().ifPresent(v -> args.put("ssh_scan_timeout", v));
-        cfg.getSudo().ifPresent(v -> args.put("ssh_sudo", v));
-        cfg.getSSHMaxProcs().ifPresent(v -> args.put("ssh_max_procs", v));
-        cfg.getUser().ifPresent(v -> args.put("ssh_user", v));
-        cfg.getWipe().ifPresent(v -> args.put("ssh_wipe", v));
+        SaltSSHUtils.mapConfigPropsToArgs(cfg, args);
 
         Type xor = parameterizedType(null, Result.class,
                 parameterizedType(null, SSHResult.class, getReturnType().getType()));

--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -284,7 +284,6 @@ public class LocalCall<R> implements Call<R> {
         cfg.getNoHostKeys().ifPresent(v -> args.put("no_host_keys", v));
         cfg.getPasswd().ifPresent(v -> args.put("ssh_passwd", v));
         cfg.getPriv().ifPresent(v -> args.put("ssh_priv", v));
-        cfg.getRawShell().ifPresent(v -> args.put("raw_shell", v));
         cfg.getRefreshCache().ifPresent(v -> args.put("refresh_cache", v));
         cfg.getRemotePortForwards().ifPresent(v -> args.put("ssh_remote_port_forwards", v));
         cfg.getRoster().ifPresent(v -> args.put("roster", v));

--- a/src/main/java/com/suse/salt/netapi/calls/SaltSSHConfig.java
+++ b/src/main/java/com/suse/salt/netapi/calls/SaltSSHConfig.java
@@ -14,7 +14,6 @@ public class SaltSSHConfig {
     private final Optional<Boolean> noHostKeys;
     private final Optional<String> passwd;
     private final Optional<String> priv;
-    private final Optional<Boolean> rawShell;
     private final Optional<Boolean> refreshCache;
     private final Optional<String> remotePortForwards;
     private final Optional<String> roster;
@@ -34,7 +33,6 @@ public class SaltSSHConfig {
         noHostKeys = builder.noHostKeys;
         passwd = builder.passwd;
         priv = builder.priv;
-        rawShell = builder.rawShell;
         refreshCache = builder.refreshCache;
         remotePortForwards = builder.remotePortForwards;
         roster = builder.roster;
@@ -73,10 +71,6 @@ public class SaltSSHConfig {
 
     public Optional<String> getPriv() {
         return priv;
-    }
-
-    public Optional<Boolean> getRawShell() {
-        return rawShell;
     }
 
     public Optional<Boolean> getRefreshCache() {
@@ -131,7 +125,6 @@ public class SaltSSHConfig {
         private Optional<Boolean> noHostKeys = Optional.empty();
         private Optional<String> passwd = Optional.empty();
         private Optional<String> priv = Optional.empty();
-        private Optional<Boolean> rawShell = Optional.empty();
         private Optional<Boolean> refreshCache = Optional.empty();
         private Optional<String> remotePortForwards = Optional.empty();
         private Optional<String> roster = Optional.empty();
@@ -223,18 +216,6 @@ public class SaltSSHConfig {
          */
         public Builder priv(String priv) {
             this.priv = Optional.of(priv);
-            return this;
-        }
-
-        /**
-         * Don't execute a salt routine on the targets, execute a
-         * raw shell command.
-         *
-         * @param rawShell if command should be execute as a shell command
-         * @return this builder
-         */
-        public Builder rawShell(boolean rawShell) {
-            this.rawShell = Optional.of(rawShell);
             return this;
         }
 

--- a/src/main/java/com/suse/salt/netapi/calls/SaltSSHUtils.java
+++ b/src/main/java/com/suse/salt/netapi/calls/SaltSSHUtils.java
@@ -1,0 +1,31 @@
+package com.suse.salt.netapi.calls;
+
+import java.util.Map;
+
+/**
+ * Salt SSH utility class with shared methods.
+ */
+public class SaltSSHUtils {
+
+    public static void mapConfigPropsToArgs(SaltSSHConfig cfg, Map<String, Object> props) {
+        // Map config properties to arguments
+        cfg.getExtraFilerefs().ifPresent(v -> props.put("extra_filerefs", v));
+        cfg.getIdentitiesOnly().ifPresent(v -> props.put("ssh_identities_only", v));
+        cfg.getIgnoreHostKeys().ifPresent(v -> props.put("ignore_host_keys", v));
+        cfg.getKeyDeploy().ifPresent(v -> props.put("ssh_key_deploy", v));
+        cfg.getNoHostKeys().ifPresent(v -> props.put("no_host_keys", v));
+        cfg.getPasswd().ifPresent(v -> props.put("ssh_passwd", v));
+        cfg.getPriv().ifPresent(v -> props.put("ssh_priv", v));
+        cfg.getRefreshCache().ifPresent(v -> props.put("refresh_cache", v));
+        cfg.getRemotePortForwards()
+                .ifPresent(v -> props.put("ssh_remote_port_forwards", v));
+        cfg.getRoster().ifPresent(v -> props.put("roster", v));
+        cfg.getRosterFile().ifPresent(v -> props.put("roster_file", v));
+        cfg.getScanPorts().ifPresent(v -> props.put("ssh_scan_ports", v));
+        cfg.getScanTimeout().ifPresent(v -> props.put("ssh_scan_timeout", v));
+        cfg.getSudo().ifPresent(v -> props.put("ssh_sudo", v));
+        cfg.getSSHMaxProcs().ifPresent(v -> props.put("ssh_max_procs", v));
+        cfg.getUser().ifPresent(v -> props.put("ssh_user", v));
+        cfg.getWipe().ifPresent(v -> props.put("ssh_wipe", v));
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/calls/SaltSSHUtils.java
+++ b/src/main/java/com/suse/salt/netapi/calls/SaltSSHUtils.java
@@ -7,8 +7,12 @@ import java.util.Map;
  */
 public class SaltSSHUtils {
 
+    /**
+     * Maps config parameters to salt-ssh rest arguments
+     * @param cfg SSH configuration to read values to be converted
+     * @param props properties to be set when rest calling
+     */
     public static void mapConfigPropsToArgs(SaltSSHConfig cfg, Map<String, Object> props) {
-        // Map config properties to arguments
         cfg.getExtraFilerefs().ifPresent(v -> props.put("extra_filerefs", v));
         cfg.getIdentitiesOnly().ifPresent(v -> props.put("ssh_identities_only", v));
         cfg.getIgnoreHostKeys().ifPresent(v -> props.put("ignore_host_keys", v));

--- a/src/main/java/com/suse/salt/netapi/client/SaltClient.java
+++ b/src/main/java/com/suse/salt/netapi/client/SaltClient.java
@@ -411,14 +411,14 @@ public class SaltClient {
         return result.getResult().get(0);
     }
 
-    public <T> Map<String, Result<SSHRawResult>> runRawSSHCommand(final Target<T> target,
-            final String function)
+    public <T> Map<String, Result<SSHRawResult>> runRawSSHCommand(final String command,
+            final Target<T> target)
         throws SaltException {
         Map<String, Object> props = new HashMap<>();
         props.put("client", Client.SSH.getValue());
         props.put("tgt", target.getTarget());
         props.put("expr_form", target.getType());
-        props.put("fun", function);
+        props.put("fun", command);
         props.put("raw_shell", true);
 
         List<Map<String, Object>> list = Collections.singletonList(props);

--- a/src/main/java/com/suse/salt/netapi/client/SaltClient.java
+++ b/src/main/java/com/suse/salt/netapi/client/SaltClient.java
@@ -3,6 +3,7 @@ package com.suse.salt.netapi.client;
 import com.suse.salt.netapi.AuthModule;
 import com.suse.salt.netapi.calls.Call;
 import com.suse.salt.netapi.calls.Client;
+import com.suse.salt.netapi.calls.SaltSSHConfig;
 import com.suse.salt.netapi.calls.wheel.Key;
 import com.suse.salt.netapi.client.impl.HttpClientConnectionFactory;
 import com.suse.salt.netapi.config.ClientConfig;
@@ -412,7 +413,7 @@ public class SaltClient {
     }
 
     public <T> Map<String, Result<SSHRawResult>> runRawSSHCommand(final String command,
-            final Target<T> target)
+            final Target<T> target, SaltSSHConfig cfg)
         throws SaltException {
         Map<String, Object> props = new HashMap<>();
         props.put("client", Client.SSH.getValue());
@@ -420,6 +421,26 @@ public class SaltClient {
         props.put("expr_form", target.getType());
         props.put("fun", command);
         props.put("raw_shell", true);
+
+        // Map config properties to arguments
+        cfg.getExtraFilerefs().ifPresent(v -> props.put("extra_filerefs", v));
+        cfg.getIdentitiesOnly().ifPresent(v -> props.put("ssh_identities_only", v));
+        cfg.getIgnoreHostKeys().ifPresent(v -> props.put("ignore_host_keys", v));
+        cfg.getKeyDeploy().ifPresent(v -> props.put("ssh_key_deploy", v));
+        cfg.getNoHostKeys().ifPresent(v -> props.put("no_host_keys", v));
+        cfg.getPasswd().ifPresent(v -> props.put("ssh_passwd", v));
+        cfg.getPriv().ifPresent(v -> props.put("ssh_priv", v));
+        cfg.getRefreshCache().ifPresent(v -> props.put("refresh_cache", v));
+        cfg.getRemotePortForwards()
+                .ifPresent(v -> props.put("ssh_remote_port_forwards", v));
+        cfg.getRoster().ifPresent(v -> props.put("roster", v));
+        cfg.getRosterFile().ifPresent(v -> props.put("roster_file", v));
+        cfg.getScanPorts().ifPresent(v -> props.put("ssh_scan_ports", v));
+        cfg.getScanTimeout().ifPresent(v -> props.put("ssh_scan_timeout", v));
+        cfg.getSudo().ifPresent(v -> props.put("ssh_sudo", v));
+        cfg.getSSHMaxProcs().ifPresent(v -> props.put("ssh_max_procs", v));
+        cfg.getUser().ifPresent(v -> props.put("ssh_user", v));
+        cfg.getWipe().ifPresent(v -> props.put("ssh_wipe", v));
 
         List<Map<String, Object>> list = Collections.singletonList(props);
 

--- a/src/main/java/com/suse/salt/netapi/client/SaltClient.java
+++ b/src/main/java/com/suse/salt/netapi/client/SaltClient.java
@@ -4,6 +4,7 @@ import com.suse.salt.netapi.AuthModule;
 import com.suse.salt.netapi.calls.Call;
 import com.suse.salt.netapi.calls.Client;
 import com.suse.salt.netapi.calls.SaltSSHConfig;
+import com.suse.salt.netapi.calls.SaltSSHUtils;
 import com.suse.salt.netapi.calls.wheel.Key;
 import com.suse.salt.netapi.client.impl.HttpClientConnectionFactory;
 import com.suse.salt.netapi.config.ClientConfig;
@@ -422,25 +423,7 @@ public class SaltClient {
         props.put("fun", command);
         props.put("raw_shell", true);
 
-        // Map config properties to arguments
-        cfg.getExtraFilerefs().ifPresent(v -> props.put("extra_filerefs", v));
-        cfg.getIdentitiesOnly().ifPresent(v -> props.put("ssh_identities_only", v));
-        cfg.getIgnoreHostKeys().ifPresent(v -> props.put("ignore_host_keys", v));
-        cfg.getKeyDeploy().ifPresent(v -> props.put("ssh_key_deploy", v));
-        cfg.getNoHostKeys().ifPresent(v -> props.put("no_host_keys", v));
-        cfg.getPasswd().ifPresent(v -> props.put("ssh_passwd", v));
-        cfg.getPriv().ifPresent(v -> props.put("ssh_priv", v));
-        cfg.getRefreshCache().ifPresent(v -> props.put("refresh_cache", v));
-        cfg.getRemotePortForwards()
-                .ifPresent(v -> props.put("ssh_remote_port_forwards", v));
-        cfg.getRoster().ifPresent(v -> props.put("roster", v));
-        cfg.getRosterFile().ifPresent(v -> props.put("roster_file", v));
-        cfg.getScanPorts().ifPresent(v -> props.put("ssh_scan_ports", v));
-        cfg.getScanTimeout().ifPresent(v -> props.put("ssh_scan_timeout", v));
-        cfg.getSudo().ifPresent(v -> props.put("ssh_sudo", v));
-        cfg.getSSHMaxProcs().ifPresent(v -> props.put("ssh_max_procs", v));
-        cfg.getUser().ifPresent(v -> props.put("ssh_user", v));
-        cfg.getWipe().ifPresent(v -> props.put("ssh_wipe", v));
+        SaltSSHUtils.mapConfigPropsToArgs(cfg, props);
 
         List<Map<String, Object>> list = Collections.singletonList(props);
 

--- a/src/main/java/com/suse/salt/netapi/client/SaltClient.java
+++ b/src/main/java/com/suse/salt/netapi/client/SaltClient.java
@@ -17,6 +17,8 @@ import com.suse.salt.netapi.event.EventStream;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.parser.JsonParser;
 import com.suse.salt.netapi.results.Return;
+import com.suse.salt.netapi.results.SSHRawResult;
+import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.results.ResultInfoSet;
 
 import com.google.gson.Gson;
@@ -408,6 +410,27 @@ public class SaltClient {
         // A list with one element is returned, we take the first
         return result.getResult().get(0);
     }
+
+    public <T> Map<String, Result<SSHRawResult>> runRawSSHCommand(final Target<T> target,
+            final String function)
+        throws SaltException {
+        Map<String, Object> props = new HashMap<>();
+        props.put("client", Client.SSH.getValue());
+        props.put("tgt", target.getTarget());
+        props.put("expr_form", target.getType());
+        props.put("fun", function);
+        props.put("raw_shell", true);
+
+        List<Map<String, Object>> list = Collections.singletonList(props);
+
+        String payload = gson.toJson(list);
+
+        Return<List<Map<String, Result<SSHRawResult>>>> result = connectionFactory
+                .create("/run", JsonParser.RUNSSHRAW_RESULTS, config).getResult(payload);
+
+        return result.getResult().get(0);
+    }
+
 
     /**
      * Asynchronously start any execution command bypassing normal session handling.

--- a/src/main/java/com/suse/salt/netapi/client/SaltClient.java
+++ b/src/main/java/com/suse/salt/netapi/client/SaltClient.java
@@ -413,6 +413,19 @@ public class SaltClient {
         return result.getResult().get(0);
     }
 
+    /**
+     * Calls salt-ssh with a command in raw shell mode (commands bypass Salt and
+     * gets executed as shell commands).
+     *
+     * @param <T> type of the tgt property for this command
+     * @param command to be executed
+     * @param target glob type, targets to be reached by the command
+     * @param cfg SaltSSH config holder
+     * @return a map in which every key is a host associated to the result of the
+     * raw command
+     * @throws SaltException
+     */
+
     public <T> Map<String, Result<SSHRawResult>> runRawSSHCommand(final String command,
             final Target<T> target, SaltSSHConfig cfg)
         throws SaltException {

--- a/src/main/java/com/suse/salt/netapi/parser/JsonParser.java
+++ b/src/main/java/com/suse/salt/netapi/parser/JsonParser.java
@@ -123,5 +123,4 @@ public class JsonParser<T> {
         return gson.fromJson(jsonString, type.getType());
     }
 
-
 }

--- a/src/main/java/com/suse/salt/netapi/parser/JsonParser.java
+++ b/src/main/java/com/suse/salt/netapi/parser/JsonParser.java
@@ -8,13 +8,13 @@ import com.suse.salt.netapi.datatypes.ScheduledJob;
 import com.suse.salt.netapi.datatypes.StartTime;
 import com.suse.salt.netapi.datatypes.Token;
 import com.suse.salt.netapi.datatypes.cherrypy.Stats;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import com.suse.salt.netapi.results.Return;
 import com.suse.salt.netapi.results.ResultInfoSet;
-
+import com.suse.salt.netapi.results.Result;
+import com.suse.salt.netapi.results.SSHRawResult;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -66,6 +66,9 @@ public class JsonParser<T> {
             new TypeToken<Return<List<Map<String, Map<String, Object>>>>>(){});
     public static final JsonParser<Return<List<Map<String, Object>>>> RUN_RESULTS =
             new JsonParser<>(new TypeToken<Return<List<Map<String, Object>>>>(){});
+    public static final JsonParser<Return<List<Map<String, Result<SSHRawResult>>>>>
+            RUNSSHRAW_RESULTS = new JsonParser<>(
+                    new TypeToken<Return<List<Map<String, Result<SSHRawResult>>>>>() { });
     public static final JsonParser<Stats> STATS =
             new JsonParser<>(new TypeToken<Stats>(){});
     public static final JsonParser<Return<Key.Names>> KEYS =

--- a/src/main/java/com/suse/salt/netapi/results/SSHRawResult.java
+++ b/src/main/java/com/suse/salt/netapi/results/SSHRawResult.java
@@ -1,7 +1,7 @@
 package com.suse.salt.netapi.results;
 
 /**
- * Wrapper class for salt-ssh results.
+ * Wrapper class for salt-ssh raw calls results.
  *
  */
 public class SSHRawResult {

--- a/src/main/java/com/suse/salt/netapi/results/SSHRawResult.java
+++ b/src/main/java/com/suse/salt/netapi/results/SSHRawResult.java
@@ -6,6 +6,16 @@ package com.suse.salt.netapi.results;
  */
 public class SSHRawResult {
 
+    public SSHRawResult() {
+
+    }
+
+    public SSHRawResult(int retcode, String stdout, String stderr) {
+        this.retcode = retcode;
+        this.stdout = stdout;
+        this.stderr = stderr;
+    }
+
     private int retcode;
     private String stderr;
     private String stdout;
@@ -20,5 +30,12 @@ public class SSHRawResult {
 
     public String getStdout() {
         return stdout;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        SSHRawResult other = (SSHRawResult) obj;
+        return other.getRetcode() == retcode && other.getStderr().equals(stderr)
+                && other.getStdout().equals(stdout);
     }
 }

--- a/src/main/java/com/suse/salt/netapi/results/SSHRawResult.java
+++ b/src/main/java/com/suse/salt/netapi/results/SSHRawResult.java
@@ -1,0 +1,24 @@
+package com.suse.salt.netapi.results;
+
+/**
+ * Wrapper class for salt-ssh results.
+ *
+ */
+public class SSHRawResult {
+
+    private int retcode;
+    private String stderr;
+    private String stdout;
+
+    public int getRetcode() {
+        return retcode;
+    }
+
+    public String getStderr() {
+        return stderr;
+    }
+
+    public String getStdout() {
+        return stdout;
+    }
+}

--- a/src/test/resources/ssh_raw_run_request.json
+++ b/src/test/resources/ssh_raw_run_request.json
@@ -1,0 +1,9 @@
+[
+  {
+    "client": "ssh",
+    "tgt": "*",
+    "expr_form": "glob",
+    "raw_shell": true,
+    "fun": "uptime"
+  }
+]

--- a/src/test/resources/ssh_raw_run_response.json
+++ b/src/test/resources/ssh_raw_run_response.json
@@ -1,0 +1,11 @@
+{
+  "return": [
+    {
+      "sumarm30": {
+        "retcode": 0,
+        "stderr": "Could not create directory '/srv/salt/.ssh'.\r\nFailed to add the host to the list of known hosts (/srv/salt/.ssh/known_hosts).\r\n",
+        "stdout": "Password: \n 17:42pm  up  19:16,  0 users,  load average: 0.00, 0.01, 0.05\n"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Current implementation for `salt-ssh` raw command execution lacks the parameter for launching the command.
This PR implements "raw shell" command execution for `salt-ssh` in another method which will be used for raw command only.

Reference: https://docs.saltstack.com/en/latest/topics/ssh/#raw-shell-calls