### PR TITLE
Prevent wrong target types from being passed to salt ssh

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -5,6 +5,7 @@ import static com.suse.salt.netapi.utils.ClientUtils.parameterizedType;
 import com.suse.salt.netapi.AuthModule;
 import com.suse.salt.netapi.client.SaltClient;
 import com.suse.salt.netapi.datatypes.Batch;
+import com.suse.salt.netapi.datatypes.target.SSHTarget;
 import com.suse.salt.netapi.datatypes.target.Target;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.results.Result;
@@ -270,7 +271,7 @@ public class LocalCall<R> implements Call<R> {
      * @throws SaltException if anything goes wrong
      */
     public Map<String, Result<SSHResult<R>>> callSyncSSH(final SaltClient client,
-            Target<?> target, SaltSSHConfig cfg) throws SaltException {
+            SSHTarget<?> target, SaltSSHConfig cfg) throws SaltException {
         Map<String, Object> args = new HashMap<>();
         args.putAll(getPayload());
         args.put("tgt", target.getTarget());

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Glob.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Glob.java
@@ -3,7 +3,7 @@ package com.suse.salt.netapi.datatypes.target;
 /**
  * Target for specifying minions by glob pattern.
  */
-public class Glob implements Target<String> {
+public class Glob implements Target<String>, SSHTarget<String> {
 
     public static final Glob ALL = new Glob("*");
 

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/MinionList.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/MinionList.java
@@ -6,7 +6,7 @@ import java.util.List;
 /**
  * Target for specifying a list of minions.
  */
-public class MinionList implements Target<List<String>> {
+public class MinionList implements Target<List<String>>, SSHTarget<List<String>> {
 
     private final List<String> targets;
 

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/SSHTarget.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/SSHTarget.java
@@ -1,0 +1,10 @@
+package com.suse.salt.netapi.datatypes.target;
+
+/**
+ * Target interface for specifying a group of minions.
+ * Target types implementing this interface can be used with salt-ssh
+ *
+ * @param <T> Type of tgt property when making a request
+ */
+public interface SSHTarget<T> extends Target<T> {
+}

--- a/src/test/java/com/suse/salt/netapi/calls/LocalCallTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/LocalCallTest.java
@@ -19,6 +19,7 @@ import com.suse.salt.netapi.client.SaltClient;
 import com.suse.salt.netapi.client.SaltClientTest;
 import com.suse.salt.netapi.datatypes.Batch;
 import com.suse.salt.netapi.datatypes.target.Glob;
+import com.suse.salt.netapi.datatypes.target.SSHTarget;
 import com.suse.salt.netapi.datatypes.target.Target;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.utils.ClientUtils;
@@ -134,7 +135,7 @@ public class LocalCallTest {
                 .withBody(JSON_SSH_PING_RESPONSE)));
 
         LocalCall<Boolean> run = com.suse.salt.netapi.calls.modules.Test.ping();
-        Target<String> target = new Glob("*");
+        SSHTarget<String> target = new Glob("*");
         SaltSSHConfig config = new SaltSSHConfig.Builder()
                 .extraFilerefs("my/file/ref")
                 .identitiesOnly(true)

--- a/src/test/java/com/suse/salt/netapi/examples/SaltSSH.java
+++ b/src/test/java/com/suse/salt/netapi/examples/SaltSSH.java
@@ -5,7 +5,7 @@ import com.suse.salt.netapi.calls.modules.Grains;
 import com.suse.salt.netapi.calls.modules.Test;
 import com.suse.salt.netapi.client.SaltClient;
 import com.suse.salt.netapi.datatypes.target.Glob;
-import com.suse.salt.netapi.datatypes.target.Target;
+import com.suse.salt.netapi.datatypes.target.SSHTarget;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.results.SSHResult;
@@ -29,7 +29,7 @@ public class SaltSSH {
         SaltSSHConfig sshConfig = new SaltSSHConfig.Builder().build();
 
         // Ping all minions using a glob matcher
-        Target<String> globTarget = new Glob("*");
+        SSHTarget<String> globTarget = new Glob("*");
         Map<String, Result<SSHResult<Boolean>>> minionResults =
                 Test.ping().callSyncSSH(client, globTarget, sshConfig);
 


### PR DESCRIPTION
Salt ssh has a limited set of target types it can handle (compared to normal salt) see https://docs.saltstack.com/en/latest/topics/ssh/#targeting-with-salt-ssh.

Due to this its currently possible to call salt ssh in our netapi library with parameters that will not work.

The plan is to only accept target types that salt ssh can handle.
One way to achieve this would be an additional marker interface that is only implemented by targets that can be used with salt ssh.