### PR TITLE
status.uptime was not working

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/modules/Status.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/Status.java
@@ -6,7 +6,6 @@ import com.google.gson.reflect.TypeToken;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/com/suse/salt/netapi/calls/modules/Status.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/Status.java
@@ -86,12 +86,9 @@ public class Status {
                 new TypeToken<Map<Integer, Map<String, String>>>(){});
     }
 
-    public static LocalCall<Float> uptime() {
-        LinkedHashMap<String, Object> args = new LinkedHashMap<>();
-        // This requires salt-master version to be >= 2015.8.4
-        args.put("human_readable", false);
-        return new LocalCall<>("status.uptime", Optional.empty(), Optional.of(args),
-                new TypeToken<Float>(){});
+    public static LocalCall<String> uptime() {
+        return new LocalCall<>("status.uptime", Optional.empty(), Optional.empty(),
+                new TypeToken<String>(){});
     }
 
     public static LocalCall<String> version() {

--- a/src/main/java/com/suse/salt/netapi/calls/modules/Status.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/Status.java
@@ -85,9 +85,9 @@ public class Status {
                 new TypeToken<Map<Integer, Map<String, String>>>(){});
     }
 
-    public static LocalCall<String> uptime() {
+    public static LocalCall<Map<String, Object>> uptime() {
         return new LocalCall<>("status.uptime", Optional.empty(), Optional.empty(),
-                new TypeToken<String>(){});
+                new TypeToken<Map<String, Object>>(){});
     }
 
     public static LocalCall<String> version() {


### PR DESCRIPTION
Hi,

Status.uptime was not working. https://github.com/SUSE/salt-netapi-client/issues/179

I removed the human_readable argument, as it was reported invalid. Changed the return type from Float to String.

Stefan