### PR TITLE
Support for config.get and additional result types

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/modules/Config.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/Config.java
@@ -1,0 +1,31 @@
+package com.suse.salt.netapi.calls.modules;
+
+import com.google.gson.reflect.TypeToken;
+import com.suse.salt.netapi.calls.LocalCall;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Returns configuration information from minions.
+ */
+public class Config {
+
+    /** The configuration key for the master's hostname. */
+    public static final String MASTER = "master";
+
+    private Config() { }
+
+    /**
+     * Returns a configuration parameter.
+     * @param key the parameter name
+     * @return the {@link LocalCall} object to make the call
+     */
+    public static LocalCall<String> get(String key) {
+        return new LocalCall<>(
+            "config.get",
+            Optional.of(Arrays.asList(key)),
+            Optional.empty(),
+            new TypeToken<String>() { });
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/results/ModuleRun.java
+++ b/src/main/java/com/suse/salt/netapi/results/ModuleRun.java
@@ -1,0 +1,49 @@
+package com.suse.salt.netapi.results;
+
+/**
+ * result of a module.run in a state file
+ * @param <R> inner changes type
+ */
+public class ModuleRun<R> {
+
+    private final R changes;
+    private final String comment;
+    private final boolean result;
+
+    /**
+     * constructor
+     *
+     * @param changesIn changes
+     * @param commentIn comment
+     * @param resultIn result
+     */
+    public ModuleRun(R changesIn, String commentIn, boolean resultIn) {
+        this.changes = changesIn;
+        this.comment = commentIn;
+        this.result = resultIn;
+    }
+
+    /**
+     * get changes
+     * @return changes
+     */
+    public R getChanges() {
+        return changes;
+    }
+
+    /**
+     * get comment
+     * @return comment
+     */
+    public String getComment() {
+        return comment;
+    }
+
+    /**
+     * get result
+     * @return result
+     */
+    public boolean isResult() {
+        return result;
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/results/OldNew.java
+++ b/src/main/java/com/suse/salt/netapi/results/OldNew.java
@@ -1,0 +1,40 @@
+package com.suse.salt.netapi.results;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * result of package install/update
+ */
+public class OldNew {
+
+    @SerializedName("old")
+    private final String oldVersion;
+    @SerializedName("new")
+    private final String newVersion;
+
+    /**
+     * constructor
+     * @param oldVersionIn old version
+     * @param newVersionIn new version
+     */
+    public OldNew(String oldVersionIn, String newVersionIn) {
+        this.oldVersion = oldVersionIn;
+        this.newVersion = newVersionIn;
+    }
+
+    /**
+     * the old version
+     * @return old version
+     */
+    public String getOldVersion() {
+        return oldVersion;
+    }
+
+    /**
+     * the new version
+     * @return new version
+     */
+    public String getNewVersion() {
+        return newVersion;
+    }
+}


### PR DESCRIPTION
This adds initial support for the `config` execution module as well as some result types for other salt calls. @mateiw and @lucidd, should we merge this for 0.10.0?