### PR TITLE
Fix date format for Schedule (bsc#1034465)

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/modules/Schedule.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/Schedule.java
@@ -83,7 +83,7 @@ public class Schedule {
         args.put("job_kwargs", payload.get("kwarg"));
 
         args.put("name", name);
-        args.put("once", once.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        args.put("once", once.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")));
         args.put("metadata", metadata);
         return new LocalCall<>("schedule.add", Optional.empty(), Optional.of(args),
                 new TypeToken<Result>() { });

--- a/src/test/java/com/suse/salt/netapi/calls/modules/ScheduleTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/ScheduleTest.java
@@ -9,6 +9,9 @@ import static org.junit.Assert.assertNotNull;
 
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Before;
@@ -77,5 +80,21 @@ public class ScheduleTest {
         assertEquals(2.0, job.get("maxrunning"));
         assertEquals(60.0, job.get("minutes"));
     }
-}
 
+    /**
+     * Salt cannot parse schedule dates that include a fraction of seconds. This test
+     * should make sure that a fraction of seconds is cut off before the request is sent.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public final void testAddDateTimeFormat() throws SaltException {
+        LocalDateTime scheduleDate = LocalDateTime.of(2017, 12, 24, 15, 30, 12, 345000000);
+        assertEquals("2017-12-24T15:30:12.345",
+                scheduleDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        LocalCall<com.suse.salt.netapi.calls.modules.Schedule.Result> call =
+                Schedule.add("Test Job", com.suse.salt.netapi.calls.modules.Test.ping(),
+                        scheduleDate, Collections.EMPTY_MAP);
+        Map<String, Object> kwarg = (Map<String, Object>) call.getPayload().get("kwarg");
+        assertEquals("2017-12-24T15:30:12", kwarg.get("once"));
+    }
+}


### PR DESCRIPTION
The Java built in [`DateTimeFormatter.ISO_LOCAL_DATE_TIME`](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_LOCAL_DATE_TIME) seems to keep the fraction of seconds while it was actually supposed to cut it off. This patch should fix a bug resulting in the following error on the Salt minion side:

```
2017-03-28 16:51:33,963 [salt.utils.schedule][ERROR   ][11430] Date string could not be parsed: 2017-03-28T17:51:29.182, %Y-%m-%dT%H:%M:%S
```