### PR TITLE
fix sending kwarg in payload in RunnerCall

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/RunnerCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/RunnerCall.java
@@ -44,7 +44,7 @@ public class RunnerCall<R> implements Call<R> {
     public Map<String, Object> getPayload() {
         HashMap<String, Object> payload = new HashMap<>();
         payload.put("fun", functionName);
-        kwargs.ifPresent(kwargs -> payload.put("kwargs", kwargs));
+        kwargs.ifPresent(kwargs -> payload.put("kwarg", kwargs));
         return payload;
     }
 

--- a/src/test/resources/async_via_event_list_job_request.json
+++ b/src/test/resources/async_via_event_list_job_request.json
@@ -1,6 +1,6 @@
 [
   {
-    "kwargs": {
+    "kwarg": {
       "jid": "20161115135014396739"
     },
     "client": "runner_async",


### PR DESCRIPTION
using kwarg's' as keyword seems to be wrong and is not working anymore with salt 2016.11.4 .
It works with older versions but maybe only by accident. Using 'kwarg' seems to work with old and new versions.

Maybe somebody can check this with salt. The docs are not that clear.