### PR TITLE
Increase the default SOCKET_TIMEOUT to 20 seconds

### DIFF
--- a/src/main/java/com/suse/salt/netapi/config/ClientConfig.java
+++ b/src/main/java/com/suse/salt/netapi/config/ClientConfig.java
@@ -24,9 +24,9 @@ public class ClientConfig {
      * Timeout in milliseconds for waiting for data.
      * A timeout of zero is interpreted as an infinite timeout.
      * A negative value is interpreted as undefined (system default).
-     * Default value is 10000ms (10s)
+     * Default value is 20000ms (20s)
      */
-    public static final Key<Integer> SOCKET_TIMEOUT = new Key<>(10000);
+    public static final Key<Integer> SOCKET_TIMEOUT = new Key<>(20000);
 
     // Proxy settings
     public static final Key<String> PROXY_HOSTNAME = new Key<>();


### PR DESCRIPTION
It should be longer than the defaults in Salt (15 seconds) so you won't get timeout exceptions with the default settings (see #184).