### PR TITLE
Allow use of XorTypeAdapter for general Xor types

### DIFF
--- a/src/main/java/com/suse/salt/netapi/parser/XorTypeAdapterFactory.java
+++ b/src/main/java/com/suse/salt/netapi/parser/XorTypeAdapterFactory.java
@@ -39,14 +39,64 @@ public class XorTypeAdapterFactory implements TypeAdapterFactory {
         boolean isParameterized = type instanceof ParameterizedType;
         boolean isSSHResult = ResultSSHResultTypeAdapterFactory.isResultSSHResult(type);
         if (isXor && isParameterized && !isSSHResult) {
+            Type leftType = ((ParameterizedType) type).getActualTypeArguments()[0];
             Type rightType = ((ParameterizedType) type).getActualTypeArguments()[1];
-            TypeAdapter<?> elementAdapter = gson.getAdapter(TypeToken.get(rightType));
-            return (TypeAdapter<A>) errorAdapter(elementAdapter);
+            TypeAdapter<?> rightAdapter = gson.getAdapter(TypeToken.get(rightType));
+            if (leftType.equals(SaltError.class)) {
+                return (TypeAdapter<A>) errorAdapter(rightAdapter);
+            }
+
+            TypeAdapter<?> leftAdapter = gson.getAdapter(TypeToken.get(leftType));
+            return (TypeAdapter<A>) xorAdapter(leftAdapter, rightAdapter);
         } else {
             return null;
         }
     }
 
+    /**
+     * Creates a generic Xor adapter by combining two other adapters - one for each side of
+     * the Xor type. It will first try to parse incoming JSON data as the right type and, if
+     * that does not succeed, it will try again with the left type.
+     *
+     * All exceptions besides the possible parsing Exception of the left type are not
+     * caught.
+     *
+     * @param <L> the generic type for the left side of the Xor
+     * @param <R> the generic type for the right side of the Xor
+     * @param leftAdapter the left adapter
+     * @param rightAdapter the right adapter
+     * @return the Xor adapter
+     */
+    private <L, R> TypeAdapter<Xor<L, R>> xorAdapter(TypeAdapter<L> leftAdapter,
+            TypeAdapter<R> rightAdapter) {
+        return new TypeAdapter<Xor<L, R>>() {
+            @Override
+            public Xor<L, R> read(JsonReader in) throws IOException {
+                JsonElement json = TypeAdapters.JSON_ELEMENT.read(in);
+                try {
+                    R value = rightAdapter.fromJsonTree(json);
+                    return Xor.right(value);
+                } catch (Throwable e) {
+                    L value = leftAdapter.fromJsonTree(json);
+                    return Xor.left(value);
+                }
+            }
+
+            @Override
+            public void write(JsonWriter out, Xor<L, R> xor) throws IOException {
+                throw new JsonParseException("Writing Xor is not supported");
+            }
+        };
+    }
+
+    /**
+     * Creates a Xor adapter specifically for the case in which the left side is a
+     * SaltError. This is used to catch any Salt-side or JSON parsing errors.
+     *
+     * @param <R> the generic type for the right side of the Xor
+     * @param innerAdapter the inner adapter
+     * @return the Xor type adapter
+     */
     private <R> TypeAdapter<Xor<SaltError, R>> errorAdapter(TypeAdapter<R> innerAdapter) {
         return new TypeAdapter<Xor<SaltError, R>>() {
             @Override


### PR DESCRIPTION
Currently XorTypeAdapterFactory assumes the left side of the type is always a SaltError - that is currently the case but prevents using more complex Xor types, when returned data from Salt might come in different
'structures'.

This allows XorTypeAdapterFactory to work with any generic Xor type.