### PR TITLE
Allow using randomly generated directory to deploy salt-thin

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/SaltSSHConfig.java
+++ b/src/main/java/com/suse/salt/netapi/calls/SaltSSHConfig.java
@@ -14,6 +14,7 @@ public class SaltSSHConfig {
     private final Optional<Boolean> noHostKeys;
     private final Optional<String> passwd;
     private final Optional<String> priv;
+    private final Optional<Boolean> randomThinDir;
     private final Optional<Boolean> refreshCache;
     private final Optional<String> remotePortForwards;
     private final Optional<String> roster;
@@ -33,6 +34,7 @@ public class SaltSSHConfig {
         noHostKeys = builder.noHostKeys;
         passwd = builder.passwd;
         priv = builder.priv;
+        randomThinDir = builder.randomThinDir;
         refreshCache = builder.refreshCache;
         remotePortForwards = builder.remotePortForwards;
         roster = builder.roster;
@@ -71,6 +73,10 @@ public class SaltSSHConfig {
 
     public Optional<String> getPriv() {
         return priv;
+    }
+
+    public Optional<Boolean> getRandomThinDir() {
+        return randomThinDir;
     }
 
     public Optional<Boolean> getRefreshCache() {
@@ -125,6 +131,7 @@ public class SaltSSHConfig {
         private Optional<Boolean> noHostKeys = Optional.empty();
         private Optional<String> passwd = Optional.empty();
         private Optional<String> priv = Optional.empty();
+        private Optional<Boolean> randomThinDir = Optional.empty();
         private Optional<Boolean> refreshCache = Optional.empty();
         private Optional<String> remotePortForwards = Optional.empty();
         private Optional<String> roster = Optional.empty();
@@ -216,6 +223,17 @@ public class SaltSSHConfig {
          */
         public Builder priv(String priv) {
             this.priv = Optional.of(priv);
+            return this;
+        }
+
+        /**
+         * Force the salt-thin to be deployed in a random path every time salt-ssh is called
+         *
+         * @param randomThinDir value to set
+         * @return this builder
+         */
+        public Builder randomThinDir(boolean randomThinDir) {
+            this.randomThinDir = Optional.of(randomThinDir);
             return this;
         }
 

--- a/src/main/java/com/suse/salt/netapi/calls/SaltSSHUtils.java
+++ b/src/main/java/com/suse/salt/netapi/calls/SaltSSHUtils.java
@@ -20,6 +20,7 @@ public class SaltSSHUtils {
         cfg.getNoHostKeys().ifPresent(v -> props.put("no_host_keys", v));
         cfg.getPasswd().ifPresent(v -> props.put("ssh_passwd", v));
         cfg.getPriv().ifPresent(v -> props.put("ssh_priv", v));
+        cfg.getRandomThinDir().ifPresent(v -> props.put("rand_thin_dir", v));
         cfg.getRefreshCache().ifPresent(v -> props.put("refresh_cache", v));
         cfg.getRemotePortForwards()
                 .ifPresent(v -> props.put("ssh_remote_port_forwards", v));

--- a/src/test/java/com/suse/salt/netapi/calls/LocalCallTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/LocalCallTest.java
@@ -190,6 +190,7 @@ public class LocalCallTest {
                 .noHostKeys(true)
                 .passwd("pa55wd")
                 .priv("/home/user/.ssh/id_rsa")
+                .randomThinDir(true)
                 .refreshCache(true)
                 .remotePortForwards("8888:my.host:443")
                 .roster("flat")

--- a/src/test/resources/ssh_ping_request.json
+++ b/src/test/resources/ssh_ping_request.json
@@ -7,6 +7,7 @@
     "extra_filerefs": "my/file/ref",
     "ignore_host_keys": true,
     "no_host_keys": true,
+    "rand_thin_dir": true,
     "refresh_cache": true,
     "roster": "flat",
     "roster_file": "/tmp/my-roster",


### PR DESCRIPTION
This PR enables `randomThinDir` as parameter for the `SaltSSHConfig` builder. This new parameter will be mapped as salt-ssh `rand_thin_dir` option.

Using a random directory to deploy the salt-thin is needed on SUSE Manager to avoid a race condition when multiple "salt-ssh" calls are made using `wipe=True` and using the default "thin_dir".

Extra information included on the bug report: https://bugzilla.suse.com/show_bug.cgi?id=1055338