### PR TITLE
Allow custom lowstate data to be passed onto SaltClient.startCommand

### DIFF
--- a/src/main/java/com/suse/salt/netapi/client/SaltClient.java
+++ b/src/main/java/com/suse/salt/netapi/client/SaltClient.java
@@ -278,7 +278,28 @@ public class SaltClient {
      */
     public <T> ScheduledJob startCommand(final Target<T> target, final String function,
             List<Object> args, Map<String, Object> kwargs) throws SaltException {
-        Map<String, Object> props = new LinkedHashMap<>();
+        return this.startCommand(target, function, args, kwargs, new HashMap<>());
+    }
+
+    /**
+     * Generic interface to start any execution command and immediately return an object
+     * representing the scheduled job.
+     * <p>
+     * {@code POST /minions}
+     *
+     * @param <T> type of the tgt property for this command
+     * @param target the target
+     * @param function the function to execute
+     * @param args list of non-keyword arguments
+     * @param kwargs map containing keyword arguments
+     * @param defaultProps default lowstate properties to be passed (e.g. jid)
+     * @return object representing the scheduled job
+     * @throws SaltException if anything goes wrong
+     */
+    public <T> ScheduledJob startCommand(final Target<T> target, final String function,
+            List<Object> args, Map<String, Object> kwargs, Map<String, Object> defaultProps)
+	           throws SaltException {
+        Map<String, Object> props = new LinkedHashMap<>(defaultProps);
         props.put("tgt", target.getTarget());
         props.put("expr_form", target.getType());
         props.put("fun", function);

--- a/src/test/java/com/suse/salt/netapi/client/SaltClientTest.java
+++ b/src/test/java/com/suse/salt/netapi/client/SaltClientTest.java
@@ -70,6 +70,8 @@ public class SaltClientTest {
 
     static final String JSON_START_COMMAND_REQUEST = ClientUtils.streamToString(
             SaltClientTest.class.getResourceAsStream("/minions_request.json"));
+    static final String JSON_START_COMMAND_REQUEST_WITH_JID = ClientUtils.streamToString(
+            SaltClientTest.class.getResourceAsStream("/minions_request_with_jid.json"));
     static final String JSON_START_COMMAND_RESPONSE = ClientUtils.streamToString(
             SaltClientTest.class.getResourceAsStream("/minions_response.json"));
     static final String JSON_GET_MINIONS_RESPONSE = ClientUtils.streamToString(
@@ -442,6 +444,32 @@ public class SaltClientTest {
         assertNotNull(job);
         assertEquals("20150211105524392307", job.getJid());
         assertEquals(Arrays.asList("myminion"), job.getMinions());
+    }
+
+    @Test
+    public void testStartCommandWithCustomJid() throws Exception {
+        stubFor(any(urlMatching(".*"))
+                .willReturn(aResponse()
+                .withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_START_COMMAND_RESPONSE)));
+
+        List<Object> args = new ArrayList<>();
+        args.add("i3");
+
+        Map<String, Object> kwargs = new LinkedHashMap<>();
+        kwargs.put("refresh", "true");
+        kwargs.put("sysupgrade", "false");
+
+        Map<String, Object> props = new LinkedHashMap<>();
+        props.put("jid", "customjid");
+
+        client.startCommand(new Glob(), "pkg.install", args, kwargs, props);
+
+        verify(1, postRequestedFor(urlEqualTo("/minions"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
+                .withRequestBody(equalToJson(JSON_START_COMMAND_REQUEST_WITH_JID)));
     }
 
     @Test

--- a/src/test/resources/minions_request_with_jid.json
+++ b/src/test/resources/minions_request_with_jid.json
@@ -1,0 +1,14 @@
+[
+  {
+    "jid": "customjid",
+    "expr_form": "glob",
+    "tgt": "*",
+    "fun": "pkg.install",
+    "arg": ["i3"],
+    "kwarg": {
+      "refresh": "true",
+      "sysupgrade": "false"
+    }
+  }
+]
+


### PR DESCRIPTION
Fixes #216

Test was created to verify the custom properties are present in request data. Since there is no need to verify the actual response (already handled in `testStartCommand`), I didn't include those asserts.