### PR TITLE
Implement CompoundMatcher target

### DIFF
--- a/src/main/java/com/suse/salt/netapi/datatypes/target/CompoundMatcher.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/CompoundMatcher.java
@@ -1,0 +1,37 @@
+package com.suse.salt.netapi.datatypes.target;
+
+/**
+ *
+ * Target for referencing compound matcher.
+ */
+public class CompoundMatcher implements Target<String> {
+
+    private final String matcher;
+
+    /**
+     * Constructor expecting a matcher as string.
+     *
+     * @param matcher
+     *            the compound matcher as string
+     */
+    public CompoundMatcher(String matcher) {
+        this.matcher = matcher;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getTarget() {
+        return matcher;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getType() {
+        return "compound";
+    }
+}
+

--- a/src/main/java/com/suse/salt/netapi/results/ResultInfo.java
+++ b/src/main/java/com/suse/salt/netapi/results/ResultInfo.java
@@ -34,7 +34,7 @@ public class ResultInfo {
     private String user;
 
     @SerializedName("Target")
-    private String target;
+    private Object target;
 
     @SerializedName("Result")
     private HashMap<String, Return<Object>> rawResults;
@@ -91,7 +91,7 @@ public class ResultInfo {
      *
      * @return job submission target
      */
-    public String getTarget() {
+    public Object getTarget() {
         return target;
     }
 


### PR DESCRIPTION
This PR brings the possibility to use compound matchers when targeting minions (as discussed in #103), but changes ResultInfo API a bit due to different data returned from API.

As discussed in the issue, I couldn't really think of how this should be tested.
