### PR TITLE
Support salt.runners.event + example code

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/runner/Event.java
+++ b/src/main/java/com/suse/salt/netapi/calls/runner/Event.java
@@ -1,0 +1,25 @@
+package com.suse.salt.netapi.calls.runner;
+
+import com.suse.salt.netapi.calls.RunnerCall;
+
+import com.google.gson.reflect.TypeToken;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * salt.runners.event
+ */
+public class Event {
+
+    private Event() { }
+
+    public static RunnerCall<Boolean> send(String tag, Optional<Map<String, Object>> data) {
+        LinkedHashMap<String, Object> args = new LinkedHashMap<>();
+        args.put("tag", tag);
+        data.ifPresent(d -> args.put("data", d));
+        return new RunnerCall<>("event.send", Optional.of(args),
+                new TypeToken<Boolean>(){});
+    }
+}

--- a/src/test/java/com/suse/salt/netapi/calls/runner/EventTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/runner/EventTest.java
@@ -1,0 +1,74 @@
+package com.suse.salt.netapi.calls.runner;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.junit.Assert.assertTrue;
+
+import com.suse.salt.netapi.calls.modules.SaltUtilTest;
+import com.suse.salt.netapi.client.SaltClient;
+import com.suse.salt.netapi.exception.SaltException;
+import com.suse.salt.netapi.utils.ClientUtils;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Tests for salt.runners.event
+ */
+public class EventTest {
+
+    private static final int MOCK_HTTP_PORT = 8888;
+
+    static final String JSON_EVENT_SEND_REQUEST = ClientUtils.streamToString(
+            SaltUtilTest.class.getResourceAsStream("/runner/event_send_request.json"));
+    static final String JSON_EVENT_SEND_RESPONSE = ClientUtils.streamToString(
+            SaltUtilTest.class.getResourceAsStream("/runner/event_send_response.json"));
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(MOCK_HTTP_PORT);
+
+    private SaltClient client;
+
+    @Before
+    public void init() {
+        URI uri = URI.create("http://localhost:" + Integer.toString(MOCK_HTTP_PORT));
+        client = new SaltClient(uri);
+    }
+
+    @Test
+    public void testEventSend() throws SaltException {
+        stubFor(any(urlMatching("/"))
+                .willReturn(aResponse().withStatus(HttpURLConnection.HTTP_OK)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JSON_EVENT_SEND_RESPONSE)));
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("foo", "bar");
+        data.put("some-value", 2);
+
+        boolean success = Event.send("my/custom/event", Optional.of(data))
+                .callSync(client).result().get();
+
+        assertTrue(success);
+        verify(1, postRequestedFor(urlEqualTo("/"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
+                .withRequestBody(equalToJson(JSON_EVENT_SEND_REQUEST)));
+    }
+}

--- a/src/test/java/com/suse/salt/netapi/examples/Runner.java
+++ b/src/test/java/com/suse/salt/netapi/examples/Runner.java
@@ -1,0 +1,41 @@
+package com.suse.salt.netapi.examples;
+
+import com.suse.salt.netapi.AuthModule;
+import com.suse.salt.netapi.calls.runner.Event;
+import com.suse.salt.netapi.calls.runner.Manage;
+import com.suse.salt.netapi.client.SaltClient;
+import com.suse.salt.netapi.exception.SaltException;
+import com.suse.salt.netapi.results.Result;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Example code calling runner functions.
+ */
+public class Runner {
+
+    private static final String SALT_API_URL = "http://localhost:8000";
+    private static final String USER = "saltdev";
+    private static final String PASSWORD = "saltdev";
+
+    public static void main(String[] args) throws SaltException {
+        // Init the client
+        SaltClient client = new SaltClient(URI.create(SALT_API_URL));
+
+        // Send a custom event with some data (salt.runners.event)
+        Map<String, Object> data = new HashMap<>();
+        data.put("foo", "bar");
+        Result<Boolean> result = Event.send("my/custom/event", Optional.of(data))
+                .callSync(client, USER, PASSWORD, AuthModule.AUTO);
+        System.out.println("event.send: " + result);
+
+        // List all minions that are up (salt.runners.manage)
+        Result<List<String>> resultUp = Manage.present()
+                .callSync(client, USER, PASSWORD, AuthModule.AUTO);
+        System.out.println("manage.present: " + resultUp);
+    }
+}

--- a/src/test/resources/runner/event_send_request.json
+++ b/src/test/resources/runner/event_send_request.json
@@ -1,0 +1,13 @@
+[
+  {
+    "kwarg": {
+      "tag":"my/custom/event",
+      "data": {
+        "foo": "bar",
+        "some-value": 2
+      }
+    },
+    "client": "runner",
+    "fun": "event.send"
+  }
+]

--- a/src/test/resources/runner/event_send_response.json
+++ b/src/test/resources/runner/event_send_response.json
@@ -1,0 +1,1 @@
+{"return": [true]}


### PR DESCRIPTION
This patch adds support for the [event runner module](https://docs.saltstack.com/en/latest/ref/runners/all/salt.runners.event.html) that allows to send custom events on the Salt event bus. There is also some example code showing how to call runner modules using the library.