### PR TITLE
[WIP] Async and non-blocking HTTP backend

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,11 @@
       <version>4.5</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpasyncclient</artifactId>
+      <version>4.1.3</version>
+    </dependency>
+    <dependency>
       <groupId>javax.websocket</groupId>
       <artifactId>javax.websocket-api</artifactId>
       <version>1.1</version>

--- a/src/main/java/com/suse/salt/netapi/client/AsyncConnection.java
+++ b/src/main/java/com/suse/salt/netapi/client/AsyncConnection.java
@@ -1,0 +1,25 @@
+package com.suse.salt.netapi.client;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Interface for different HTTP async connection implementations.
+ * @param <T> type of result retrieved using this HTTP connection
+ */
+public interface AsyncConnection<T> {
+
+    /**
+     * Send a GET request and parse the result into object of given type.
+     *
+     * @return CompletionStage holding object of the given return type T
+     */
+    CompletionStage<T> get();
+
+    /**
+     * Send a POST request and parse the result into object of given type.
+     *
+     * @param data the data to send (in JSON format)
+     * @return CompletionStage holding object of the given return type T
+     */
+    CompletionStage<T> post(String data);
+}

--- a/src/main/java/com/suse/salt/netapi/client/AsyncConnectionFactory.java
+++ b/src/main/java/com/suse/salt/netapi/client/AsyncConnectionFactory.java
@@ -1,0 +1,19 @@
+package com.suse.salt.netapi.client;
+
+import com.suse.salt.netapi.parser.JsonParser;
+
+/**
+ * Interface for creating instances of an HTTP async connection implementation.
+ */
+public interface AsyncConnectionFactory extends AutoCloseable {
+
+    /**
+     * Create a new {@link AsyncConnection} for a given endpoint and configuration.
+     *
+     * @param <T> type of the result as returned by the parser
+     * @param endpoint the API endpoint
+     * @param parser the parser used for parsing the result
+     * @return object representing a connection to the API
+     */
+    <T> AsyncConnection<T> create(String endpoint, JsonParser<T> parser);
+}

--- a/src/main/java/com/suse/salt/netapi/client/SaltClient.java
+++ b/src/main/java/com/suse/salt/netapi/client/SaltClient.java
@@ -5,6 +5,7 @@ import com.suse.salt.netapi.calls.Call;
 import com.suse.salt.netapi.calls.Client;
 import com.suse.salt.netapi.calls.SaltSSHConfig;
 import com.suse.salt.netapi.calls.SaltSSHUtils;
+import com.suse.salt.netapi.client.impl.HttpAsyncClientConnectionFactory;
 import com.suse.salt.netapi.client.impl.HttpClientConnectionFactory;
 import com.suse.salt.netapi.config.ClientConfig;
 import com.suse.salt.netapi.config.ProxySettings;
@@ -23,13 +24,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.concurrent.FutureCallback;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
-
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,7 +31,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -46,13 +39,16 @@ import java.util.concurrent.Future;
 /**
  * Salt API client.
  */
-public class SaltClient {
+public class SaltClient implements AutoCloseable {
 
     /** The configuration object */
     private final ClientConfig config = new ClientConfig();
 
     /** The connection factory object */
     private final ConnectionFactory connectionFactory;
+
+    /** The async connection factory object */
+    private final AsyncConnectionFactory asyncConnectionFactory;
 
     /** The executor for async operations */
     private final ExecutorService executor;
@@ -101,6 +97,9 @@ public class SaltClient {
         config.put(ClientConfig.URL, url);
         this.connectionFactory = connectionFactory;
         this.executor = executor;
+
+        // TODO: Replace connectionFactory with this
+        this.asyncConnectionFactory = new HttpAsyncClientConnectionFactory(config);
     }
 
     /**
@@ -135,53 +134,31 @@ public class SaltClient {
      * <p>
      * {@code POST /login}
      *
-     * @param httpclient the HTTP client
-     * @param username username
-     * @param password password
-     * @param eauth authentication module
-     * @return completion stage
+     * @param username the username
+     * @param password the password
+     * @param eauth the eauth type
+     * @return CompletionStage holding the authentication token
      */
-    public CompletionStage<Token> loginNonBlocking(CloseableHttpAsyncClient httpclient,
-            final String username, final String password, final AuthModule eauth) {
+    public CompletionStage<Token> loginNonBlocking(final String username,
+            final String password, final AuthModule eauth) {
         Map<String, String> props = new LinkedHashMap<>();
         props.put("username", username);
         props.put("password", password);
         props.put("eauth", eauth.getValue());
+
         String payload = gson.toJson(props);
 
-        CompletableFuture<Token> future = new CompletableFuture<>();
-
-        final HttpPost request = new HttpPost(config.get(ClientConfig.URL) + "/login");
-        request.setEntity(new StringEntity(payload, ContentType.APPLICATION_JSON));
-        httpclient.execute(request, new FutureCallback<HttpResponse>() {
-
-            @Override
-            public void failed(Exception e) {
-                future.completeExceptionally(e);
-            }
-
-            @Override
-            public void completed(HttpResponse response) {
-                try {
-                    Return<List<Token>> result = JsonParser.TOKEN
-                            .parse(response.getEntity().getContent());
-
-                    // They return a list of tokens here, take the first
-                    Token token = result.getResult().get(0);
+        CompletionStage<Token> result = asyncConnectionFactory
+                .create("/login", JsonParser.TOKEN)
+                .post(payload)
+                .thenApply(r -> {
+                    // They return a list of tokens here, take the first one
+                    Token token = r.getResult().get(0);
                     config.put(ClientConfig.TOKEN, token.getToken());
-                    future.complete(token);
-                } catch (Exception e) {
-                    future.completeExceptionally(e);
-                }
-            }
+                    return token;
+                });
 
-            @Override
-            public void cancelled() {
-                future.cancel(false);
-            }
-        });
-
-        return future;
+        return result;
     }
 
     /**
@@ -447,5 +424,10 @@ public class SaltClient {
     public <R> R call(Call<?> call, Client client, String endpoint, TypeToken<R> type)
             throws SaltException {
         return call(call, client, endpoint, Optional.empty(), type);
+    }
+
+    @Override
+    public void close() throws Exception {
+        asyncConnectionFactory.close();
     }
 }

--- a/src/main/java/com/suse/salt/netapi/client/impl/HttpAsyncClientConnection.java
+++ b/src/main/java/com/suse/salt/netapi/client/impl/HttpAsyncClientConnection.java
@@ -1,0 +1,172 @@
+package com.suse.salt.netapi.client.impl;
+
+import com.suse.salt.netapi.client.AsyncConnection;
+import com.suse.salt.netapi.config.ClientConfig;
+import com.suse.salt.netapi.exception.SaltException;
+import com.suse.salt.netapi.exception.SaltUserUnauthorizedException;
+import com.suse.salt.netapi.parser.JsonParser;
+
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.nio.client.HttpAsyncClient;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Representation of a connection to Salt for issuing API requests using Apache's
+ * HttpAsyncClient.
+ *
+ * @param <T> type of result retrieved using this HTTP connection
+ */
+public class HttpAsyncClientConnection<T> implements AsyncConnection<T> {
+
+    /** HTTP client instance */
+    private final HttpAsyncClient httpClient;
+
+    /** Endpoint */
+    private final String endpoint;
+
+    /** Configuration */
+    private final ClientConfig config;
+
+    /** Parser to parse the returned result */
+    private final JsonParser<T> parser;
+
+    /**
+     * Init a connection to a given Salt API endpoint.
+     *
+     * @param httpClientIn the HTTP client
+     * @param endpointIn the endpoint
+     * @param parserIn the parser
+     * @param configIn the config
+     */
+    public HttpAsyncClientConnection(HttpAsyncClient httpClientIn, String endpointIn,
+            JsonParser<T> parserIn, ClientConfig configIn) {
+        httpClient = httpClientIn;
+        endpoint = endpointIn;
+        config = configIn;
+        parser = parserIn;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletionStage<T> post(String data) {
+        return request(data);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletionStage<T> get() {
+        return request(null);
+    }
+
+    /**
+     * Perform HTTP request and parse the result into a given result type.
+     *
+     * @param data the data to send with the request
+     * @return CompletionStage holding object of type T
+     */
+    private CompletionStage<T> request(String data) {
+        return executeRequest(httpClient, prepareRequest(data));
+    }
+
+    /**
+     * Prepares the HTTP request object creating a POST or GET request depending on if data
+     * is supplied or not.
+     *
+     * @param jsonData json POST data, will use GET if null
+     * @return HttpUriRequest object the prepared request
+     */
+    private HttpUriRequest prepareRequest(String jsonData) {
+        URI uri = config.get(ClientConfig.URL).resolve(endpoint);
+        HttpUriRequest httpRequest;
+        if (jsonData != null) {
+            // POST data
+            HttpPost httpPost = new HttpPost(uri);
+            httpPost.setEntity(new StringEntity(jsonData, ContentType.APPLICATION_JSON));
+            httpRequest = httpPost;
+        } else {
+            // GET request
+            httpRequest = new HttpGet(uri);
+        }
+        httpRequest.addHeader(HttpHeaders.ACCEPT, "application/json");
+
+        // Token authentication
+        String token = config.get(ClientConfig.TOKEN);
+        if (token != null) {
+            httpRequest.addHeader("X-Auth-Token", token);
+        }
+
+        return httpRequest;
+    }
+
+    /**
+     * Executes a prepared HTTP request using the given client.
+     *
+     * @param httpClient the client to use for the request
+     * @param httpRequest the prepared request to perform
+     * @return CompletionStage holding object of type T
+     */
+    private CompletionStage<T> executeRequest(HttpAsyncClient httpClient,
+            HttpUriRequest httpRequest) {
+        CompletableFuture<T> future = new CompletableFuture<>();
+        httpClient.execute(httpRequest, new FutureCallback<HttpResponse>() {
+            @Override
+            public void failed(Exception e) {
+                future.completeExceptionally(e);
+            }
+
+            @Override
+            public void completed(HttpResponse response) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode == HttpStatus.SC_OK ||
+                        statusCode == HttpStatus.SC_ACCEPTED) {
+
+                    // Parse result type from the returned JSON
+                    try {
+                        T result = parser.parse(response.getEntity().getContent());
+                        future.complete(result);
+                    } catch (Exception e) {
+                        future.completeExceptionally(e);
+                    }
+                } else {
+                    future.completeExceptionally(createSaltException(statusCode));
+                }
+            }
+
+            @Override
+            public void cancelled() {
+                future.cancel(false);
+            }
+        });
+
+        return future;
+    }
+
+    /**
+     * Create the appropriate exception for the given HTTP status code.
+     *
+     * @param statusCode HTTP status code
+     * @return {@link SaltException} instance
+     */
+    private SaltException createSaltException(int statusCode) {
+        if (statusCode == HttpStatus.SC_UNAUTHORIZED) {
+            return new SaltUserUnauthorizedException(
+                    "Salt user does not have sufficient permissions");
+        }
+        return new SaltException("Response code: " + statusCode);
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/client/impl/HttpAsyncClientConnectionFactory.java
+++ b/src/main/java/com/suse/salt/netapi/client/impl/HttpAsyncClientConnectionFactory.java
@@ -1,0 +1,129 @@
+package com.suse.salt.netapi.client.impl;
+
+import com.suse.salt.netapi.client.AsyncConnectionFactory;
+import com.suse.salt.netapi.config.ClientConfig;
+import com.suse.salt.netapi.parser.JsonParser;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
+
+/**
+ * Implementation of a factory for connections using Apache's HttpAsyncClient.
+ *
+ * @see HttpAsyncClientConnection
+ */
+public class HttpAsyncClientConnectionFactory implements AsyncConnectionFactory {
+
+    /** HTTP client instance */
+    final CloseableHttpAsyncClient httpClient;
+
+    /** Salt client configuration */
+    final ClientConfig config;
+
+    /**
+     * Constructor for creating a connection factory based on the given configuration.
+     *
+     * @param config the client configuration
+     */
+    public HttpAsyncClientConnectionFactory(ClientConfig config) {
+        this(config, initializeHttpClient(config).build());
+    }
+
+    /**
+     * Constructor for creating a connection factory based on the given custom HTTP client
+     * instance and configuration object.
+     *
+     * @param config the client configuration
+     * @param httpClient a custom HTTP client instance
+     */
+    public HttpAsyncClientConnectionFactory(ClientConfig config,
+            CloseableHttpAsyncClient httpClient) {
+        this.config = config;
+        this.httpClient = httpClient;
+        this.httpClient.start();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> HttpAsyncClientConnection<T> create(String endpoint, JsonParser<T> parser) {
+        return new HttpAsyncClientConnection<>(httpClient, endpoint, parser, config);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() throws Exception {
+        httpClient.close();
+    }
+
+    /**
+     * Initialize HttpAsyncClientBuilder based on the current ClientConfig object.
+     *
+     * @param config the client configuration
+     */
+    private static HttpAsyncClientBuilder initializeHttpClient(ClientConfig config) {
+        HttpAsyncClientBuilder httpClientBuilder = HttpAsyncClients.custom();
+        configure(httpClientBuilder, config);
+        configureProxyIfSpecified(httpClientBuilder, config);
+        return httpClientBuilder;
+    }
+
+    /**
+     * Configure the supplied HttpAsyncClientBuilder with defaults and settings from the
+     * current ClientConfig object.
+     *
+     * @param httpClientBuilder the {@link HttpAsyncClientBuilder} to be configured
+     * @param config the client configuration
+     */
+    private static void configure(HttpAsyncClientBuilder httpClientBuilder,
+            ClientConfig config) {
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(config.get(ClientConfig.CONNECT_TIMEOUT))
+                .setSocketTimeout(config.get(ClientConfig.SOCKET_TIMEOUT))
+                .setCookieSpec(CookieSpecs.STANDARD)
+                .build();
+
+        httpClientBuilder.setDefaultRequestConfig(requestConfig);
+    }
+
+    /**
+     * Configure the HttpAsyncClientBuilder with the proxy settings if specified in the
+     * ClientConfig object.
+     *
+     * @param httpClientBuilder the {@link HttpAsyncClientBuilder} to be configured
+     * @param config the client configuration
+     */
+    private static void configureProxyIfSpecified(HttpAsyncClientBuilder httpClientBuilder,
+            ClientConfig config) {
+        String proxyHost = config.get(ClientConfig.PROXY_HOSTNAME);
+        if (proxyHost != null) {
+            int proxyPort = config.get(ClientConfig.PROXY_PORT);
+
+            HttpHost proxy = new HttpHost(proxyHost, proxyPort);
+            httpClientBuilder.setProxy(proxy);
+
+            String proxyUsername = config.get(ClientConfig.PROXY_USERNAME);
+            String proxyPassword = config.get(ClientConfig.PROXY_PASSWORD);
+
+            // Proxy authentication
+            if (proxyUsername != null && proxyPassword != null) {
+                CredentialsProvider credentials = new BasicCredentialsProvider();
+                credentials.setCredentials(
+                        new AuthScope(proxyHost, proxyPort),
+                        new UsernamePasswordCredentials(proxyUsername, proxyPassword));
+                httpClientBuilder.setDefaultCredentialsProvider(credentials);
+            }
+        }
+    }
+}

--- a/src/test/java/com/suse/salt/netapi/examples/Async.java
+++ b/src/test/java/com/suse/salt/netapi/examples/Async.java
@@ -3,10 +3,6 @@ package com.suse.salt.netapi.examples;
 import com.suse.salt.netapi.AuthModule;
 import com.suse.salt.netapi.client.SaltClient;
 
-import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
-import org.apache.http.impl.nio.client.HttpAsyncClients;
-
-import java.io.IOException;
 import java.net.URI;
 
 /**
@@ -21,19 +17,18 @@ public class Async {
     public static void main(String[] args) {
         // Init the client
         SaltClient client = new SaltClient(URI.create(SALT_API_URL));
-        CloseableHttpAsyncClient httpclient = HttpAsyncClients.createDefault();
-        httpclient.start();
 
+        // Clean up afterwards by calling close()
         Runnable cleanup = () -> {
             try {
-                httpclient.close();
-            } catch (IOException e) {
+                client.close();
+            } catch (Exception e) {
                 e.printStackTrace();
             }
         };
 
         // Perform a non-blocking login
-        client.loginNonBlocking(httpclient, USER, PASSWORD, AuthModule.AUTO)
+        client.loginNonBlocking(USER, PASSWORD, AuthModule.AUTO)
                 .thenAccept(t -> System.out.println("Token -> " + t.getToken()))
                 .thenRun(cleanup);
     }

--- a/src/test/java/com/suse/salt/netapi/examples/Async.java
+++ b/src/test/java/com/suse/salt/netapi/examples/Async.java
@@ -1,0 +1,40 @@
+package com.suse.salt.netapi.examples;
+
+import com.suse.salt.netapi.AuthModule;
+import com.suse.salt.netapi.client.SaltClient;
+
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Example code using HttpAsyncClient.
+ */
+public class Async {
+
+    private static final String SALT_API_URL = "http://localhost:8000";
+    private static final String USER = "saltdev";
+    private static final String PASSWORD = "saltdev";
+
+    public static void main(String[] args) {
+        // Init the client
+        SaltClient client = new SaltClient(URI.create(SALT_API_URL));
+        CloseableHttpAsyncClient httpclient = HttpAsyncClients.createDefault();
+        httpclient.start();
+
+        Runnable cleanup = () -> {
+            try {
+                httpclient.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        };
+
+        // Perform a non-blocking login
+        client.loginNonBlocking(httpclient, USER, PASSWORD, AuthModule.AUTO)
+                .thenAccept(t -> System.out.println("Token -> " + t.getToken()))
+                .thenRun(cleanup);
+    }
+}


### PR DESCRIPTION
This patch is about replacing the existing HTTP client backend (that can run on either the Apache HTTP client or the JDK classes) with one that works in a non-blocking fashion, in this case the Apache [HttpAsyncClient](https://hc.apache.org/httpcomponents-asyncclient-dev/). The outcome of this is that we can actually benefit from the concurrency features of Java 8, especially [CompletableFuture](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html). All the main library methods will then return a [CompletionStage](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html) containing the result instead of just the result. This is why we are targeting the version 1.0.0 milestone with this patch.