### PR TITLE
Do not depend on javax.xml.bind any longer

### DIFF
--- a/src/main/java/com/suse/salt/netapi/client/impl/RequestFactory.java
+++ b/src/main/java/com/suse/salt/netapi/client/impl/RequestFactory.java
@@ -7,8 +7,7 @@ import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URL;
-
-import javax.xml.bind.DatatypeConverter;
+import java.util.Base64;
 
 /**
  * Helper class for setting up {@link HttpURLConnection} objects.
@@ -59,7 +58,7 @@ public class RequestFactory {
             String proxyUsername = config.get(ClientConfig.PROXY_USERNAME);
             String proxyPassword = config.get(ClientConfig.PROXY_PASSWORD);
             if (proxyUsername != null && proxyPassword != null) {
-                final String encoded = DatatypeConverter.printBase64Binary(
+                final String encoded = Base64.getEncoder().encodeToString(
                         (proxyUsername + ':' + proxyPassword).getBytes());
                 connection.addRequestProperty("Proxy-Authorization", encoded);
             }


### PR DESCRIPTION
For JDK9 `javax.xml.bind` is [deprecated to be removed](https://docs.oracle.com/javase/9/docs/api/java.xml.bind-summary.html) in a future version. Now as JDK8 finally includes Base64 encoding and decoding we should make use of that in order to avoid having to add an additional external library in the future.