### PR TITLE
Increase max line length to 120

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ Pull requests are always welcome, please see [issues](https://github.com/SUSE/sa
 ### Style guide
 
 * Indentations are represented with 4 spaces
-* The maximum line length should not exceed 92
+* The maximum line length should not exceed 120
 * Wrapped lines should be indented twice (8 spaces)
 * Files should end with a new line

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -13,7 +13,7 @@
             <property name="message" value="Trailing whitespace"/>
         </module>
         <module name="LineLength">
-            <property name="max" value="92"/>
+            <property name="max" value="120"/>
             <property name="ignorePattern" value="import"/>
         </module>
         <module name="Indentation">


### PR DESCRIPTION
This patch increases the checkstyle maximum line length to 120 characters.