### PR TITLE
Support the test parameter on state.apply

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/modules/State.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/State.java
@@ -35,19 +35,22 @@ public class State {
     private State() { }
 
     public static LocalCall<Map<String, ApplyResult>> apply(List<String> mods) {
-        return apply(mods, Optional.empty(), Optional.empty());
+        return apply(mods, Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     public static LocalCall<Map<String, ApplyResult>> apply(String... mods) {
-        return apply(Arrays.asList(mods), Optional.empty(), Optional.empty());
+        return apply(Arrays.asList(mods), Optional.empty(), Optional.empty(),
+                Optional.empty());
     }
 
     public static LocalCall<Map<String, ApplyResult>> apply(List<String> mods,
-            Optional<Map<String, Object>> pillar, Optional<Boolean> queue) {
+            Optional<Map<String, Object>> pillar, Optional<Boolean> queue,
+            Optional<Boolean> test) {
         Map<String, Object> kwargs = new LinkedHashMap<>();
         kwargs.put("mods", mods);
         pillar.ifPresent(p -> kwargs.put("pillar", p));
         queue.ifPresent(q -> kwargs.put("queue", q));
+        test.ifPresent(t -> kwargs.put("test", t));
         return new LocalCall<>("state.apply", Optional.empty(), Optional.of(kwargs),
                 new TypeToken<Map<String, ApplyResult>>(){});
     }


### PR DESCRIPTION
This patch adds support for the `test` parameter on calls to `state.apply`, allowing to run states in test-only (dry-run) mode (see the [docs](https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.state.html#salt.modules.state.apply)).