### PR TITLE
Support additional target types

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -130,7 +130,7 @@ public class LocalCall<R> extends AbstractCall<R> {
         Map<String, Object> customArgs = new HashMap<>();
         customArgs.putAll(getPayload());
         customArgs.put("tgt", target.getTarget());
-        customArgs.put("expr_form", target.getType());
+        customArgs.put("expr_form", target.getType().getValue());
 
         Return<List<LocalAsyncResult<R>>> wrapper = client.call(
                 this, Client.LOCAL_ASYNC, "/",
@@ -311,7 +311,7 @@ public class LocalCall<R> extends AbstractCall<R> {
         customArgs.put("password", password);
         customArgs.put("eauth", authModule.getValue());
         customArgs.put("tgt", target.getTarget());
-        customArgs.put("expr_form", target.getType());
+        customArgs.put("expr_form", target.getType().getValue());
 
         Return<List<LocalAsyncResult<R>>> wrapper = client.call(
                 this, Client.LOCAL_ASYNC, "/run",
@@ -425,7 +425,7 @@ public class LocalCall<R> extends AbstractCall<R> {
         Map<String, Object> customArgs = new HashMap<>();
         customArgs.putAll(getPayload());
         customArgs.put("tgt", target.getTarget());
-        customArgs.put("expr_form", target.getType());
+        customArgs.put("expr_form", target.getType().getValue());
         username.ifPresent(v -> customArgs.put("username", v));
         password.ifPresent(v -> customArgs.put("password", v));
         authModule.ifPresent(v -> customArgs.put("eauth", v.getValue()));
@@ -464,7 +464,7 @@ public class LocalCall<R> extends AbstractCall<R> {
         Map<String, Object> args = new HashMap<>();
         args.putAll(getPayload());
         args.put("tgt", target.getTarget());
-        args.put("expr_form", target.getType());
+        args.put("expr_form", target.getType().getValue());
 
         SaltSSHUtils.mapConfigPropsToArgs(cfg, args);
 

--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -129,8 +129,7 @@ public class LocalCall<R> extends AbstractCall<R> {
             throws SaltException {
         Map<String, Object> customArgs = new HashMap<>();
         customArgs.putAll(getPayload());
-        customArgs.put("tgt", target.getTarget());
-        customArgs.put("expr_form", target.getType().getValue());
+        customArgs.putAll(target.getProps());
 
         Return<List<LocalAsyncResult<R>>> wrapper = client.call(
                 this, Client.LOCAL_ASYNC, "/",
@@ -310,8 +309,7 @@ public class LocalCall<R> extends AbstractCall<R> {
         customArgs.put("username", username);
         customArgs.put("password", password);
         customArgs.put("eauth", authModule.getValue());
-        customArgs.put("tgt", target.getTarget());
-        customArgs.put("expr_form", target.getType().getValue());
+        customArgs.putAll(target.getProps());
 
         Return<List<LocalAsyncResult<R>>> wrapper = client.call(
                 this, Client.LOCAL_ASYNC, "/run",
@@ -424,8 +422,7 @@ public class LocalCall<R> extends AbstractCall<R> {
             throws SaltException {
         Map<String, Object> customArgs = new HashMap<>();
         customArgs.putAll(getPayload());
-        customArgs.put("tgt", target.getTarget());
-        customArgs.put("expr_form", target.getType().getValue());
+        customArgs.putAll(target.getProps());
         username.ifPresent(v -> customArgs.put("username", v));
         password.ifPresent(v -> customArgs.put("password", v));
         authModule.ifPresent(v -> customArgs.put("eauth", v.getValue()));
@@ -463,8 +460,7 @@ public class LocalCall<R> extends AbstractCall<R> {
             SSHTarget<?> target, SaltSSHConfig cfg) throws SaltException {
         Map<String, Object> args = new HashMap<>();
         args.putAll(getPayload());
-        args.put("tgt", target.getTarget());
-        args.put("expr_form", target.getType().getValue());
+        args.putAll(target.getProps());
 
         SaltSSHUtils.mapConfigPropsToArgs(cfg, args);
 

--- a/src/main/java/com/suse/salt/netapi/client/SaltClient.java
+++ b/src/main/java/com/suse/salt/netapi/client/SaltClient.java
@@ -279,8 +279,7 @@ public class SaltClient {
     public <T> ScheduledJob startCommand(final Target<T> target, final String function,
             List<Object> args, Map<String, Object> kwargs) throws SaltException {
         Map<String, Object> props = new LinkedHashMap<>();
-        props.put("tgt", target.getTarget());
-        props.put("expr_form", target.getType().getValue());
+        props.putAll(target.getProps());
         props.put("fun", function);
         props.put("arg", args);
         props.put("kwarg", kwargs);
@@ -395,8 +394,7 @@ public class SaltClient {
         props.put("password", password);
         props.put("eauth", eauth.getValue());
         props.put("client", client);
-        props.put("tgt", target.getTarget());
-        props.put("expr_form", target.getType().getValue());
+        props.putAll(target.getProps());
         props.put("fun", function);
         props.put("arg", args);
         props.put("kwarg", kwargs);
@@ -430,8 +428,7 @@ public class SaltClient {
         throws SaltException {
         Map<String, Object> props = new HashMap<>();
         props.put("client", Client.SSH.getValue());
-        props.put("tgt", target.getTarget());
-        props.put("expr_form", target.getType().getValue());
+        props.putAll(target.getProps());
         props.put("fun", command);
         props.put("raw_shell", true);
 

--- a/src/main/java/com/suse/salt/netapi/client/SaltClient.java
+++ b/src/main/java/com/suse/salt/netapi/client/SaltClient.java
@@ -280,7 +280,7 @@ public class SaltClient {
             List<Object> args, Map<String, Object> kwargs) throws SaltException {
         Map<String, Object> props = new LinkedHashMap<>();
         props.put("tgt", target.getTarget());
-        props.put("expr_form", target.getType());
+        props.put("expr_form", target.getType().getValue());
         props.put("fun", function);
         props.put("arg", args);
         props.put("kwarg", kwargs);
@@ -396,7 +396,7 @@ public class SaltClient {
         props.put("eauth", eauth.getValue());
         props.put("client", client);
         props.put("tgt", target.getTarget());
-        props.put("expr_form", target.getType());
+        props.put("expr_form", target.getType().getValue());
         props.put("fun", function);
         props.put("arg", args);
         props.put("kwarg", kwargs);
@@ -431,7 +431,7 @@ public class SaltClient {
         Map<String, Object> props = new HashMap<>();
         props.put("client", Client.SSH.getValue());
         props.put("tgt", target.getTarget());
-        props.put("expr_form", target.getType());
+        props.put("expr_form", target.getType().getValue());
         props.put("fun", command);
         props.put("raw_shell", true);
 

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/AbstractTarget.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/AbstractTarget.java
@@ -1,0 +1,29 @@
+package com.suse.salt.netapi.datatypes.target;
+
+import java.util.HashMap;
+import java.util.Map;
+
+abstract class AbstractTarget<T> {
+
+    protected final T target;
+
+    protected AbstractTarget(T target) {
+        this.target = target;
+    }
+
+    public T getTarget() {
+        return target;
+    }
+
+    abstract TargetType getType();
+
+    /**
+     * {@inheritDoc}
+     */
+    public Map<String, Object> getProps() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("tgt", getTarget());
+        props.put("expr_form", getType().getValue());
+        return props;
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/AbstractTarget.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/AbstractTarget.java
@@ -2,13 +2,14 @@ package com.suse.salt.netapi.datatypes.target;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 abstract class AbstractTarget<T> {
 
     protected final T target;
 
     protected AbstractTarget(T target) {
-        this.target = target;
+        this.target = Objects.requireNonNull(target);
     }
 
     public T getTarget() {

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/AbstractTarget.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/AbstractTarget.java
@@ -4,6 +4,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * Base class for all target types
+ *
+ * @param <T> The data type of the target class
+ */
 abstract class AbstractTarget<T> {
 
     protected final T target;
@@ -19,7 +24,7 @@ abstract class AbstractTarget<T> {
     abstract TargetType getType();
 
     /**
-     * {@inheritDoc}
+     * @return a map of items to include in the API call payload
      */
     public Map<String, Object> getProps() {
         Map<String, Object> props = new HashMap<>();

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/AbstractTarget.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/AbstractTarget.java
@@ -12,16 +12,18 @@ import java.util.Objects;
 abstract class AbstractTarget<T> {
 
     protected final T target;
+    protected final TargetType type;
 
-    protected AbstractTarget(T target) {
+    protected AbstractTarget(TargetType type, T target) {
         this.target = Objects.requireNonNull(target);
+        this.type = Objects.requireNonNull(type);
     }
 
     public T getTarget() {
         return target;
     }
 
-    abstract TargetType getType();
+    public TargetType getType() { return type; }
 
     /**
      * @return a map of items to include in the API call payload

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Compound.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Compound.java
@@ -8,11 +8,8 @@ public class Compound extends AbstractTarget<String> implements Target<String> {
     /**
      * Default constructor.
      */
-    public Compound(String expression) { super(expression); }
+    public Compound(String expression) {
+        super(TargetType.COMPOUND, expression);
+    }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TargetType getType() { return TargetType.COMPOUND; }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Compound.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Compound.java
@@ -1,0 +1,18 @@
+package com.suse.salt.netapi.datatypes.target;
+
+/**
+ * Target for specifying minions by compound expression.
+ */
+public class Compound extends AbstractTarget<String> implements Target<String> {
+
+    /**
+     * Default constructor.
+     */
+    public Compound(String expression) { super(expression); }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TargetType getType() { return TargetType.COMPOUND; }
+}

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Compound.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Compound.java
@@ -6,10 +6,10 @@ package com.suse.salt.netapi.datatypes.target;
 public class Compound extends AbstractTarget<String> implements Target<String> {
 
     /**
-     * Default constructor.
+     * Creates a compound matcher
+     *
+     * @param expression Compound targeting expression
      */
-    public Compound(String expression) {
-        super(TargetType.COMPOUND, expression);
-    }
+    public Compound(String expression) { super(TargetType.COMPOUND, expression); }
 
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/DictionaryTarget.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/DictionaryTarget.java
@@ -5,6 +5,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * Base class for all grain and pillar target types
+ */
 abstract class DictionaryTarget extends AbstractTarget<String> {
 
     public final static char DEFAULT_DELIMITER = ':';
@@ -63,6 +66,10 @@ abstract class DictionaryTarget extends AbstractTarget<String> {
         return delimiter;
     }
 
+    /**
+     * @return a map of items to include in the API call payload
+     *         This will include the 'delimiter' key if not using the default delimiter.
+     */
     @Override
     public Map<String, Object> getProps() {
         Map<String, Object> props = super.getProps();

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/DictionaryTarget.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/DictionaryTarget.java
@@ -1,7 +1,9 @@
 package com.suse.salt.netapi.datatypes.target;
 
+import java.security.InvalidParameterException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 abstract class DictionaryTarget extends AbstractTarget<String> {
 
@@ -17,10 +19,16 @@ abstract class DictionaryTarget extends AbstractTarget<String> {
 
     public DictionaryTarget(String target, char delimiter) {
         super(target);
+        this.delimiter = Objects.requireNonNull(delimiter);
+
         int pos = target.lastIndexOf(delimiter);
+        if (pos < 1 || pos == target.length() - 1) {
+            // The delimiter was not found, or was
+            // found and the start or end of the string
+            throw new InvalidParameterException();
+        }
         this.key = target.substring(0, pos);
         this.value = target.substring(pos + 1);
-        this.delimiter = delimiter;
     }
 
     public DictionaryTarget(String key, String value) {
@@ -29,9 +37,9 @@ abstract class DictionaryTarget extends AbstractTarget<String> {
 
     public DictionaryTarget(String key, String value, char delimiter) {
         super(key + delimiter + value);
-        this.key = key;
-        this.value = value;
-        this.delimiter = delimiter;
+        this.key = Objects.requireNonNull(key);
+        this.value = Objects.requireNonNull(value);
+        this.delimiter = Objects.requireNonNull(delimiter);
     }
 
     /**

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/DictionaryTarget.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/DictionaryTarget.java
@@ -1,0 +1,66 @@
+package com.suse.salt.netapi.datatypes.target;
+
+import java.util.HashMap;
+import java.util.Map;
+
+abstract class DictionaryTarget extends AbstractTarget<String> {
+
+    public final static char DEFAULT_DELIMITER = ':';
+
+    protected final String key;
+    protected final String value;
+    protected final char delimiter;
+
+    public DictionaryTarget(String target) {
+        this(target, DEFAULT_DELIMITER);
+    }
+
+    public DictionaryTarget(String target, char delimiter) {
+        super(target);
+        int pos = target.lastIndexOf(delimiter);
+        this.key = target.substring(0, pos);
+        this.value = target.substring(pos + 1);
+        this.delimiter = delimiter;
+    }
+
+    public DictionaryTarget(String key, String value) {
+        this(key, value, DEFAULT_DELIMITER);
+    }
+
+    public DictionaryTarget(String key, String value, char delimiter) {
+        super(key + delimiter + value);
+        this.key = key;
+        this.value = value;
+        this.delimiter = delimiter;
+    }
+
+    /**
+     * @return the grain name of this matcher
+     */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * @return the value to match the grain
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * @return the delimiter used by this target
+     */
+    public char getDelimiter() {
+        return delimiter;
+    }
+
+    @Override
+    public Map<String, Object> getProps() {
+        Map<String, Object> props = super.getProps();
+        if (getDelimiter() != DEFAULT_DELIMITER) {
+            props.put("delimiter", getDelimiter());
+        }
+        return props;
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/DictionaryTarget.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/DictionaryTarget.java
@@ -16,12 +16,12 @@ abstract class DictionaryTarget extends AbstractTarget<String> {
     protected final String value;
     protected final char delimiter;
 
-    public DictionaryTarget(String target) {
-        this(target, DEFAULT_DELIMITER);
+    public DictionaryTarget(TargetType type, String target) {
+        this(type, target, DEFAULT_DELIMITER);
     }
 
-    public DictionaryTarget(String target, char delimiter) {
-        super(target);
+    public DictionaryTarget(TargetType type, String target, char delimiter) {
+        super(type, target);
         this.delimiter = Objects.requireNonNull(delimiter);
 
         int pos = target.lastIndexOf(delimiter);
@@ -34,12 +34,12 @@ abstract class DictionaryTarget extends AbstractTarget<String> {
         this.value = target.substring(pos + 1);
     }
 
-    public DictionaryTarget(String key, String value) {
-        this(key, value, DEFAULT_DELIMITER);
+    public DictionaryTarget(TargetType type, String key, String value) {
+        this(type, key, value, DEFAULT_DELIMITER);
     }
 
-    public DictionaryTarget(String key, String value, char delimiter) {
-        super(key + delimiter + value);
+    public DictionaryTarget(TargetType type, String key, String value, char delimiter) {
+        super(type, key + delimiter + value);
         this.key = Objects.requireNonNull(key);
         this.value = Objects.requireNonNull(value);
         this.delimiter = Objects.requireNonNull(delimiter);

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/DictionaryTarget.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/DictionaryTarget.java
@@ -1,7 +1,6 @@
 package com.suse.salt.netapi.datatypes.target;
 
 import java.security.InvalidParameterException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -16,13 +15,13 @@ abstract class DictionaryTarget extends AbstractTarget<String> {
     protected final String value;
     protected final char delimiter;
 
-    public DictionaryTarget(TargetType type, String target) {
+    DictionaryTarget(TargetType type, String target) {
         this(type, target, DEFAULT_DELIMITER);
     }
 
-    public DictionaryTarget(TargetType type, String target, char delimiter) {
+    DictionaryTarget(TargetType type, String target, char delimiter) {
         super(type, target);
-        this.delimiter = Objects.requireNonNull(delimiter);
+        this.delimiter = delimiter;
 
         int pos = target.lastIndexOf(delimiter);
         if (pos < 1 || pos == target.length() - 1) {
@@ -34,15 +33,15 @@ abstract class DictionaryTarget extends AbstractTarget<String> {
         this.value = target.substring(pos + 1);
     }
 
-    public DictionaryTarget(TargetType type, String key, String value) {
+    DictionaryTarget(TargetType type, String key, String value) {
         this(type, key, value, DEFAULT_DELIMITER);
     }
 
-    public DictionaryTarget(TargetType type, String key, String value, char delimiter) {
+    DictionaryTarget(TargetType type, String key, String value, char delimiter) {
         super(type, key + delimiter + value);
         this.key = Objects.requireNonNull(key);
         this.value = Objects.requireNonNull(value);
-        this.delimiter = Objects.requireNonNull(delimiter);
+        this.delimiter = delimiter;
     }
 
     /**
@@ -73,7 +72,7 @@ abstract class DictionaryTarget extends AbstractTarget<String> {
     @Override
     public Map<String, Object> getProps() {
         Map<String, Object> props = super.getProps();
-        if (getDelimiter() != DEFAULT_DELIMITER) {
+        if (delimiter != DEFAULT_DELIMITER) {
             props.put("delimiter", getDelimiter());
         }
         return props;

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Glob.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Glob.java
@@ -8,15 +8,18 @@ public class Glob extends AbstractTarget<String> implements Target<String>, SSHT
     public static final Glob ALL = new Glob("*");
 
     /**
-     * Default constructor.
+     * Creates a glob matcher
      */
-    public Glob() { super("*"); }
-
-    public Glob(String glob) { super(glob); }
+    public Glob() {
+        super(TargetType.GLOB, "*");
+    }
 
     /**
-     * {@inheritDoc}
+     * Creates a glob matcher
+     * @param glob Glob expression
      */
-    @Override
-    public TargetType getType() { return TargetType.GLOB; }
+    public Glob(String glob) {
+        super(TargetType.GLOB, glob);
+    }
+
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Glob.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Glob.java
@@ -10,16 +10,13 @@ public class Glob extends AbstractTarget<String> implements Target<String>, SSHT
     /**
      * Creates a glob matcher
      */
-    public Glob() {
-        super(TargetType.GLOB, "*");
-    }
+    public Glob() { super(TargetType.GLOB, "*"); }
 
     /**
      * Creates a glob matcher
+     *
      * @param glob Glob expression
      */
-    public Glob(String glob) {
-        super(TargetType.GLOB, glob);
-    }
+    public Glob(String glob) { super(TargetType.GLOB, glob); }
 
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Glob.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Glob.java
@@ -37,7 +37,7 @@ public class Glob implements Target<String>, SSHTarget<String> {
      * {@inheritDoc}
      */
     @Override
-    public String getType() {
-        return "glob";
+    public TargetType getType() {
+        return TargetType.GLOB;
     }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Glob.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Glob.java
@@ -10,19 +10,13 @@ public class Glob extends AbstractTarget<String> implements Target<String>, SSHT
     /**
      * Default constructor.
      */
-    public Glob() {
-        super("*");
-    }
+    public Glob() { super("*"); }
 
-    public Glob(String glob) {
-        super(glob);
-    }
+    public Glob(String glob) { super(glob); }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public TargetType getType() {
-        return TargetType.GLOB;
-    }
+    public TargetType getType() { return TargetType.GLOB; }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Glob.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Glob.java
@@ -3,34 +3,19 @@ package com.suse.salt.netapi.datatypes.target;
 /**
  * Target for specifying minions by glob pattern.
  */
-public class Glob implements Target<String>, SSHTarget<String> {
+public class Glob extends AbstractTarget<String> implements Target<String>, SSHTarget<String> {
 
     public static final Glob ALL = new Glob("*");
-
-    private final String glob;
 
     /**
      * Default constructor.
      */
     public Glob() {
-        this("*");
+        super("*");
     }
 
-    /**
-     * Constructor expecting a glob pattern as string.
-     *
-     * @param glob glob pattern
-     */
     public Glob(String glob) {
-        this.glob = glob;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getTarget() {
-        return glob;
+        super(glob);
     }
 
     /**

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Grains.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Grains.java
@@ -52,7 +52,7 @@ public class Grains extends DictionaryTarget implements Target<String> {
     public TargetType getType() { return TargetType.GRAIN; }
 
     /**
-     * Return the grain identifier key
+     * @return the grain identifier key
      *
      * @deprecated
      * Use {@link #getKey()} instead.

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Grains.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Grains.java
@@ -11,7 +11,7 @@ public class Grains extends DictionaryTarget implements Target<String> {
      * @param target the targeting expression
      */
     public Grains(String target) {
-        super(target);
+        super(TargetType.GRAIN, target);
     }
 
     /**
@@ -21,7 +21,7 @@ public class Grains extends DictionaryTarget implements Target<String> {
      * @param delimiter the character to delimit nesting in the grain name
      */
     public Grains(String target, char delimiter) {
-        super(target, delimiter);
+        super(TargetType.GRAIN, target, delimiter);
     }
 
     /**
@@ -31,7 +31,7 @@ public class Grains extends DictionaryTarget implements Target<String> {
      * @param value the value to match
      */
     public Grains(String grain, String value) {
-        super(grain, value);
+        super(TargetType.GRAIN, grain, value);
     }
 
     /**
@@ -42,14 +42,8 @@ public class Grains extends DictionaryTarget implements Target<String> {
      * @param delimiter the character to delimit nesting in the grain name
      */
     public Grains(String grain, String value, char delimiter) {
-        super(grain, value, delimiter);
+        super(TargetType.GRAIN, grain, value, delimiter);
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TargetType getType() { return TargetType.GRAIN; }
 
     /**
      * @return the grain identifier key

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Grains.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Grains.java
@@ -1,13 +1,17 @@
 package com.suse.salt.netapi.datatypes.target;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Matcher based on salt grains
  */
-public class Grains implements Target<String> {
+public class Grains extends AbstractTarget<String> implements Target<String> {
 
     private final String grain;
     private final String value;
-    private final String target;
+    private final char delimiter;
+    public final static char DEFAULT_DELIMITER = ':';
 
     /**
      * Creates a grains matcher
@@ -16,9 +20,21 @@ public class Grains implements Target<String> {
      * @param value the value to match
      */
     public Grains(String grain, String value) {
+        this(grain, value, DEFAULT_DELIMITER);
+    }
+
+    /**
+     * Creates a grains matcher
+     *
+     * @param grain the grain name
+     * @param value the value to match
+     * @param delimiter the character to delimit nesting in the grain name
+     */
+    public Grains(String grain, String value, char delimiter) {
+        super(grain + delimiter + value);
         this.grain = grain;
         this.value = value;
-        this.target = grain + ":" + value;
+        this.delimiter = delimiter;
     }
 
     /**
@@ -35,13 +51,26 @@ public class Grains implements Target<String> {
         return value;
     }
 
-    @Override
-    public String getTarget() {
-        return target;
+    /**
+     * @return the delimiter used by this target
+     */
+    public char getDelimiter() {
+        return delimiter;
     }
 
     @Override
     public TargetType getType() {
         return TargetType.GRAIN;
+    }
+
+    @Override
+    public Map<String, Object> getProps() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("tgt", getTarget());
+        props.put("expr_form", getType().getValue());
+        if (getDelimiter() != DEFAULT_DELIMITER) {
+            props.put("delimiter", getDelimiter());
+        }
+        return props;
     }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Grains.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Grains.java
@@ -1,17 +1,28 @@
 package com.suse.salt.netapi.datatypes.target;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Matcher based on salt grains
  */
-public class Grains extends AbstractTarget<String> implements Target<String> {
+public class Grains extends DictionaryTarget implements Target<String> {
 
-    private final String grain;
-    private final String value;
-    private final char delimiter;
-    public final static char DEFAULT_DELIMITER = ':';
+    /**
+     * Creates a grains matcher
+     *
+     * @param target the targeting expression
+     */
+    public Grains(String target) {
+        super(target);
+    }
+
+    /**
+     * Creates a grains matcher
+     *
+     * @param target the targeting expression
+     * @param delimiter the character to delimit nesting in the grain name
+     */
+    public Grains(String target, char delimiter) {
+        super(target, delimiter);
+    }
 
     /**
      * Creates a grains matcher
@@ -20,7 +31,7 @@ public class Grains extends AbstractTarget<String> implements Target<String> {
      * @param value the value to match
      */
     public Grains(String grain, String value) {
-        this(grain, value, DEFAULT_DELIMITER);
+        super(grain, value);
     }
 
     /**
@@ -31,46 +42,16 @@ public class Grains extends AbstractTarget<String> implements Target<String> {
      * @param delimiter the character to delimit nesting in the grain name
      */
     public Grains(String grain, String value, char delimiter) {
-        super(grain + delimiter + value);
-        this.grain = grain;
-        this.value = value;
-        this.delimiter = delimiter;
+        super(grain, value, delimiter);
     }
 
     /**
-     * @return the grain name of this matcher
+     * {@inheritDoc}
      */
-    public String getGrain() {
-        return grain;
-    }
-
-    /**
-     * @return the value to match the grain
-     */
-    public String getValue() {
-        return value;
-    }
-
-    /**
-     * @return the delimiter used by this target
-     */
-    public char getDelimiter() {
-        return delimiter;
-    }
-
     @Override
-    public TargetType getType() {
-        return TargetType.GRAIN;
-    }
+    public TargetType getType() { return TargetType.GRAIN; }
 
-    @Override
-    public Map<String, Object> getProps() {
-        Map<String, Object> props = new HashMap<>();
-        props.put("tgt", getTarget());
-        props.put("expr_form", getType().getValue());
-        if (getDelimiter() != DEFAULT_DELIMITER) {
-            props.put("delimiter", getDelimiter());
-        }
-        return props;
-    }
+
+    @Deprecated
+    public String getGrain() { return getKey(); }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Grains.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Grains.java
@@ -41,7 +41,7 @@ public class Grains implements Target<String> {
     }
 
     @Override
-    public String getType() {
-        return "grain";
+    public TargetType getType() {
+        return TargetType.GRAIN;
     }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Grains.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Grains.java
@@ -51,7 +51,12 @@ public class Grains extends DictionaryTarget implements Target<String> {
     @Override
     public TargetType getType() { return TargetType.GRAIN; }
 
-
+    /**
+     * Return the grain identifier key
+     *
+     * @deprecated
+     * Use {@link #getKey()} instead.
+     */
     @Deprecated
     public String getGrain() { return getKey(); }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/GrainsRegEx.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/GrainsRegEx.java
@@ -11,7 +11,7 @@ public class GrainsRegEx extends DictionaryTarget implements Target<String> {
      * @param target the targeting expression
      */
     public GrainsRegEx(String target) {
-        super(target);
+        super(TargetType.GRAIN_PCRE, target);
     }
 
     /**
@@ -21,7 +21,7 @@ public class GrainsRegEx extends DictionaryTarget implements Target<String> {
      * @param delimiter the character to delimit nesting in the grain name
      */
     public GrainsRegEx(String target, char delimiter) {
-        super(target, delimiter);
+        super(TargetType.GRAIN_PCRE, target, delimiter);
     }
 
     /**
@@ -31,7 +31,7 @@ public class GrainsRegEx extends DictionaryTarget implements Target<String> {
      * @param regex the regular expression to match
      */
     public GrainsRegEx(String grain, String regex) {
-        super(grain, regex);
+        super(TargetType.GRAIN_PCRE, grain, regex);
     }
 
     /**
@@ -42,14 +42,7 @@ public class GrainsRegEx extends DictionaryTarget implements Target<String> {
      * @param delimiter the character to delimit nesting in the grain name
      */
     public GrainsRegEx(String grain, String regex, char delimiter) {
-        super(grain, regex, delimiter);
+        super(TargetType.GRAIN_PCRE, grain, regex, delimiter);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TargetType getType() {
-        return TargetType.GRAIN_PCRE;
-    }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/GrainsRegEx.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/GrainsRegEx.java
@@ -1,0 +1,55 @@
+package com.suse.salt.netapi.datatypes.target;
+
+/**
+ * Matcher based on salt grains
+ */
+public class GrainsRegEx extends DictionaryTarget implements Target<String> {
+
+    /**
+     * Creates a grains matcher
+     *
+     * @param target the targeting expression
+     */
+    public GrainsRegEx(String target) {
+        super(target);
+    }
+
+    /**
+     * Creates a grains matcher
+     *
+     * @param target the targeting expression
+     * @param delimiter the character to delimit nesting in the grain name
+     */
+    public GrainsRegEx(String target, char delimiter) {
+        super(target, delimiter);
+    }
+
+    /**
+     * Creates a grains matcher
+     *
+     * @param grain the grain name
+     * @param regex the regular expression to match
+     */
+    public GrainsRegEx(String grain, String regex) {
+        super(grain, regex);
+    }
+
+    /**
+     * Creates a grains matcher
+     *
+     * @param grain the grain name
+     * @param regex the regular expression to match
+     * @param delimiter the character to delimit nesting in the grain name
+     */
+    public GrainsRegEx(String grain, String regex, char delimiter) {
+        super(grain, regex, delimiter);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TargetType getType() {
+        return TargetType.GRAIN_PCRE;
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/IPCidr.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/IPCidr.java
@@ -8,11 +8,8 @@ public class IPCidr extends AbstractTarget<String> implements Target<String> {
     /**
      * Default constructor.
      */
-    public IPCidr(String cidr) { super(cidr); }
+    public IPCidr(String cidr) {
+        super(TargetType.IPCIDR, cidr);
+    }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TargetType getType() { return TargetType.IPCIDR; }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/IPCidr.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/IPCidr.java
@@ -6,7 +6,9 @@ package com.suse.salt.netapi.datatypes.target;
 public class IPCidr extends AbstractTarget<String> implements Target<String> {
 
     /**
-     * Default constructor.
+     * Creates an IPCidr matcher
+     *
+     * @param cidr CIDR targeting expression
      */
     public IPCidr(String cidr) {
         super(TargetType.IPCIDR, cidr);

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/IPCidr.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/IPCidr.java
@@ -1,0 +1,18 @@
+package com.suse.salt.netapi.datatypes.target;
+
+/**
+ * Target for specifying minions by IP CIDR.
+ */
+public class IPCidr extends AbstractTarget<String> implements Target<String> {
+
+    /**
+     * Default constructor.
+     */
+    public IPCidr(String cidr) { super(cidr); }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TargetType getType() { return TargetType.IPCIDR; }
+}

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/MinionList.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/MinionList.java
@@ -1,9 +1,7 @@
 package com.suse.salt.netapi.datatypes.target;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Target for specifying a list of minions.

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/MinionList.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/MinionList.java
@@ -14,7 +14,7 @@ public class MinionList extends AbstractTarget<List<String>> implements Target<L
      * @param targets as a list of strings
      */
     public MinionList(List<String> targets) {
-        super(targets);
+        super(TargetType.LIST, targets);
     }
 
     /**
@@ -23,12 +23,7 @@ public class MinionList extends AbstractTarget<List<String>> implements Target<L
      * @param targets as strings
      */
     public MinionList(String... targets) {
-        super(Arrays.asList(targets));
+        super(TargetType.LIST, Arrays.asList(targets));
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TargetType getType() { return TargetType.LIST; }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/MinionList.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/MinionList.java
@@ -40,7 +40,7 @@ public class MinionList implements Target<List<String>>, SSHTarget<List<String>>
      * {@inheritDoc}
      */
     @Override
-    public String getType() {
-        return "list";
+    public TargetType getType() {
+        return TargetType.LIST;
     }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/MinionList.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/MinionList.java
@@ -1,14 +1,14 @@
 package com.suse.salt.netapi.datatypes.target;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Target for specifying a list of minions.
  */
-public class MinionList implements Target<List<String>>, SSHTarget<List<String>> {
-
-    private final List<String> targets;
+public class MinionList extends AbstractTarget<List<String>> implements Target<List<String>>, SSHTarget<List<String>> {
 
     /**
      * Constructor taking a list of minions as strings.
@@ -16,7 +16,7 @@ public class MinionList implements Target<List<String>>, SSHTarget<List<String>>
      * @param targets as a list of strings
      */
     public MinionList(List<String> targets) {
-        this.targets = targets;
+        super(targets);
     }
 
     /**
@@ -25,15 +25,7 @@ public class MinionList implements Target<List<String>>, SSHTarget<List<String>>
      * @param targets as strings
      */
     public MinionList(String... targets) {
-        this(Arrays.asList(targets));
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public List<String> getTarget() {
-        return targets;
+        super(Arrays.asList(targets));
     }
 
     /**

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/MinionList.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/MinionList.java
@@ -32,7 +32,5 @@ public class MinionList extends AbstractTarget<List<String>> implements Target<L
      * {@inheritDoc}
      */
     @Override
-    public TargetType getType() {
-        return TargetType.LIST;
-    }
+    public TargetType getType() { return TargetType.LIST; }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/NodeGroup.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/NodeGroup.java
@@ -28,7 +28,7 @@ public class NodeGroup implements Target<String> {
      * {@inheritDoc}
      */
     @Override
-    public String getType() {
-        return "nodegroup";
+    public TargetType getType() {
+        return TargetType.NODEGROUP;
     }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/NodeGroup.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/NodeGroup.java
@@ -3,9 +3,7 @@ package com.suse.salt.netapi.datatypes.target;
 /**
  * Target for referencing a nodegroup.
  */
-public class NodeGroup implements Target<String> {
-
-    private final String nodegroup;
+public class NodeGroup extends AbstractTarget<String> implements Target<String> {
 
     /**
      * Constructor expecting a nodegroup as string.
@@ -13,15 +11,7 @@ public class NodeGroup implements Target<String> {
      * @param nodegroup the nodegroup as string
      */
     public NodeGroup(String nodegroup) {
-        this.nodegroup = nodegroup;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getTarget() {
-        return nodegroup;
+        super(nodegroup);
     }
 
     /**

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/NodeGroup.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/NodeGroup.java
@@ -11,12 +11,7 @@ public class NodeGroup extends AbstractTarget<String> implements Target<String> 
      * @param nodegroup the nodegroup as string
      */
     public NodeGroup(String nodegroup) {
-        super(nodegroup);
+        super(TargetType.NODEGROUP, nodegroup);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TargetType getType() { return TargetType.NODEGROUP; }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/NodeGroup.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/NodeGroup.java
@@ -18,7 +18,5 @@ public class NodeGroup extends AbstractTarget<String> implements Target<String> 
      * {@inheritDoc}
      */
     @Override
-    public TargetType getType() {
-        return TargetType.NODEGROUP;
-    }
+    public TargetType getType() { return TargetType.NODEGROUP; }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Pillar.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Pillar.java
@@ -11,7 +11,7 @@ public class Pillar extends DictionaryTarget implements Target<String> {
      * @param target the targeting expression
      */
     public Pillar(String target) {
-        super(target);
+        super(TargetType.PILLAR, target);
     }
 
     /**
@@ -21,7 +21,7 @@ public class Pillar extends DictionaryTarget implements Target<String> {
      * @param delimiter the character to delimit nesting in the grain name
      */
     public Pillar(String target, char delimiter) {
-        super(target, delimiter);
+        super(TargetType.PILLAR, target, delimiter);
     }
 
     /**
@@ -31,7 +31,7 @@ public class Pillar extends DictionaryTarget implements Target<String> {
      * @param value the value to match
      */
     public Pillar(String pillar, String value) {
-        super(pillar, value);
+        super(TargetType.PILLAR, pillar, value);
     }
 
     /**
@@ -42,11 +42,7 @@ public class Pillar extends DictionaryTarget implements Target<String> {
      * @param delimiter the character to delimit nesting in the pillar name
      */
     public Pillar(String pillar, String value, char delimiter) {
-        super(pillar, value, delimiter);
+        super(TargetType.PILLAR, pillar, value, delimiter);
     }
 
-    @Override
-    public TargetType getType() {
-        return TargetType.PILLAR;
-    }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Pillar.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Pillar.java
@@ -1,0 +1,52 @@
+package com.suse.salt.netapi.datatypes.target;
+
+/**
+ * Matcher based on salt pillar with glob matching
+ */
+public class Pillar extends DictionaryTarget implements Target<String> {
+
+    /**
+     * Creates a pillar matcher
+     *
+     * @param target the targeting expression
+     */
+    public Pillar(String target) {
+        super(target);
+    }
+
+    /**
+     * Creates a pillar matcher
+     *
+     * @param target the targeting expression
+     * @param delimiter the character to delimit nesting in the grain name
+     */
+    public Pillar(String target, char delimiter) {
+        super(target, delimiter);
+    }
+
+    /**
+     * Creates a pillar matcher
+     *
+     * @param pillar the pillar name
+     * @param value the value to match
+     */
+    public Pillar(String pillar, String value) {
+        super(pillar, value);
+    }
+
+    /**
+     * Creates a pillar matcher
+     *
+     * @param pillar the pillar name
+     * @param value the value to match
+     * @param delimiter the character to delimit nesting in the pillar name
+     */
+    public Pillar(String pillar, String value, char delimiter) {
+        super(pillar, value, delimiter);
+    }
+
+    @Override
+    public TargetType getType() {
+        return TargetType.PILLAR;
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/PillarExact.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/PillarExact.java
@@ -1,0 +1,52 @@
+package com.suse.salt.netapi.datatypes.target;
+
+/**
+ * Matcher based on salt pillar without glob matching
+ */
+public class PillarExact extends DictionaryTarget implements Target<String> {
+
+    /**
+     * Creates a pillar matcher
+     *
+     * @param target the targeting expression
+     */
+    public PillarExact(String target) {
+        super(target);
+    }
+
+    /**
+     * Creates a pillar matcher
+     *
+     * @param target the targeting expression
+     * @param delimiter the character to delimit nesting in the grain name
+     */
+    public PillarExact(String target, char delimiter) {
+        super(target, delimiter);
+    }
+
+    /**
+     * Creates a pillar matcher
+     *
+     * @param pillar the pillar name
+     * @param value the value to match
+     */
+    public PillarExact(String pillar, String value) {
+        super(pillar, value);
+    }
+
+    /**
+     * Creates a pillar matcher
+     *
+     * @param pillar the pillar name
+     * @param value the value to match
+     * @param delimiter the character to delimit nesting in the pillar name
+     */
+    public PillarExact(String pillar, String value, char delimiter) {
+        super(pillar, value, delimiter);
+    }
+
+    @Override
+    public TargetType getType() {
+        return TargetType.PILLAR_EXACT;
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/PillarExact.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/PillarExact.java
@@ -11,7 +11,7 @@ public class PillarExact extends DictionaryTarget implements Target<String> {
      * @param target the targeting expression
      */
     public PillarExact(String target) {
-        super(target);
+        super(TargetType.PILLAR_EXACT, target);
     }
 
     /**
@@ -21,7 +21,7 @@ public class PillarExact extends DictionaryTarget implements Target<String> {
      * @param delimiter the character to delimit nesting in the grain name
      */
     public PillarExact(String target, char delimiter) {
-        super(target, delimiter);
+        super(TargetType.PILLAR_EXACT, target, delimiter);
     }
 
     /**
@@ -31,7 +31,7 @@ public class PillarExact extends DictionaryTarget implements Target<String> {
      * @param value the value to match
      */
     public PillarExact(String pillar, String value) {
-        super(pillar, value);
+        super(TargetType.PILLAR_EXACT, pillar, value);
     }
 
     /**
@@ -42,11 +42,7 @@ public class PillarExact extends DictionaryTarget implements Target<String> {
      * @param delimiter the character to delimit nesting in the pillar name
      */
     public PillarExact(String pillar, String value, char delimiter) {
-        super(pillar, value, delimiter);
+        super(TargetType.PILLAR_EXACT, pillar, value, delimiter);
     }
 
-    @Override
-    public TargetType getType() {
-        return TargetType.PILLAR_EXACT;
-    }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/PillarRegEx.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/PillarRegEx.java
@@ -11,7 +11,7 @@ public class PillarRegEx extends DictionaryTarget implements Target<String> {
      * @param target the targeting expression
      */
     public PillarRegEx(String target) {
-        super(target);
+        super(TargetType.PILLAR_PCRE, target);
     }
 
     /**
@@ -21,7 +21,7 @@ public class PillarRegEx extends DictionaryTarget implements Target<String> {
      * @param delimiter the character to delimit nesting in the grain name
      */
     public PillarRegEx(String target, char delimiter) {
-        super(target, delimiter);
+        super(TargetType.PILLAR_PCRE, target, delimiter);
     }
 
     /**
@@ -31,7 +31,7 @@ public class PillarRegEx extends DictionaryTarget implements Target<String> {
      * @param regex the regular expression to match
      */
     public PillarRegEx(String pillar, String regex) {
-        super(pillar, regex);
+        super(TargetType.PILLAR_PCRE, pillar, regex);
     }
 
     /**
@@ -42,11 +42,7 @@ public class PillarRegEx extends DictionaryTarget implements Target<String> {
      * @param delimiter the character to delimit nesting in the pillar name
      */
     public PillarRegEx(String pillar, String regex, char delimiter) {
-        super(pillar, regex, delimiter);
+        super(TargetType.PILLAR_PCRE, pillar, regex, delimiter);
     }
 
-    @Override
-    public TargetType getType() {
-        return TargetType.PILLAR_PCRE;
-    }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/PillarRegEx.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/PillarRegEx.java
@@ -1,0 +1,52 @@
+package com.suse.salt.netapi.datatypes.target;
+
+/**
+ * Matcher based on salt pillar with regular expression matching
+ */
+public class PillarRegEx extends DictionaryTarget implements Target<String> {
+
+    /**
+     * Creates a pillar matcher
+     *
+     * @param target the targeting expression
+     */
+    public PillarRegEx(String target) {
+        super(target);
+    }
+
+    /**
+     * Creates a pillar matcher
+     *
+     * @param target the targeting expression
+     * @param delimiter the character to delimit nesting in the grain name
+     */
+    public PillarRegEx(String target, char delimiter) {
+        super(target, delimiter);
+    }
+
+    /**
+     * Creates a pillar matcher
+     *
+     * @param pillar the pillar name
+     * @param regex the regular expression to match
+     */
+    public PillarRegEx(String pillar, String regex) {
+        super(pillar, regex);
+    }
+
+    /**
+     * Creates a pillar matcher
+     *
+     * @param pillar the pillar name
+     * @param regex the regular expression to match
+     * @param delimiter the character to delimit nesting in the pillar name
+     */
+    public PillarRegEx(String pillar, String regex, char delimiter) {
+        super(pillar, regex, delimiter);
+    }
+
+    @Override
+    public TargetType getType() {
+        return TargetType.PILLAR_PCRE;
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Range.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Range.java
@@ -1,0 +1,20 @@
+package com.suse.salt.netapi.datatypes.target;
+
+/**
+ * Target for specifying minions by range expression.
+ */
+public class Range extends AbstractTarget<String> implements Target<String> {
+
+    /**
+     * Default constructor.
+     */
+    public Range(String expression) {
+        super(expression);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TargetType getType() { return TargetType.RANGE; }
+}

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Range.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Range.java
@@ -9,12 +9,7 @@ public class Range extends AbstractTarget<String> implements Target<String> {
      * Default constructor.
      */
     public Range(String expression) {
-        super(expression);
+        super(TargetType.RANGE, expression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TargetType getType() { return TargetType.RANGE; }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Range.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Range.java
@@ -6,10 +6,12 @@ package com.suse.salt.netapi.datatypes.target;
 public class Range extends AbstractTarget<String> implements Target<String> {
 
     /**
-     * Default constructor.
+     * Creates a range matcher
+     *
+     * @param range Range targeting expression
      */
-    public Range(String expression) {
-        super(TargetType.RANGE, expression);
+    public Range(String range) {
+        super(TargetType.RANGE, range);
     }
 
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/RegEx.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/RegEx.java
@@ -6,10 +6,12 @@ package com.suse.salt.netapi.datatypes.target;
 public class RegEx extends AbstractTarget<String> implements Target<String>, SSHTarget<String> {
 
     /**
-     * Default constructor.
+     * Creates a regular expression matcher
+     *
+     * @param regex Regular expression
      */
-    public RegEx(String expression) {
-        super(TargetType.PCRE, expression);
+    public RegEx(String regex) {
+        super(TargetType.PCRE, regex);
     }
 
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/RegEx.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/RegEx.java
@@ -1,0 +1,22 @@
+package com.suse.salt.netapi.datatypes.target;
+
+/**
+ * Target for specifying minions by regular expression.
+ */
+public class RegEx extends AbstractTarget<String> implements Target<String>, SSHTarget<String> {
+
+    /**
+     * Default constructor.
+     */
+    public RegEx(String expression) {
+        super(expression);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TargetType getType() {
+        return TargetType.PCRE;
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/RegEx.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/RegEx.java
@@ -9,14 +9,7 @@ public class RegEx extends AbstractTarget<String> implements Target<String>, SSH
      * Default constructor.
      */
     public RegEx(String expression) {
-        super(expression);
+        super(TargetType.PCRE, expression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TargetType getType() {
-        return TargetType.PCRE;
-    }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Target.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Target.java
@@ -19,5 +19,5 @@ public interface Target<T> {
      *
      * @return the target type
      */
-    public String getType();
+    public TargetType getType();
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Target.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Target.java
@@ -1,5 +1,7 @@
 package com.suse.salt.netapi.datatypes.target;
 
+import java.util.Map;
+
 /**
  * Target interface for specifying a group of minions.
  *
@@ -20,4 +22,13 @@ public interface Target<T> {
      * @return the target type
      */
     public TargetType getType();
+
+    /**
+     * Return the properties that belong in a request body.
+     * This will include the `tgt` and `expr_form` properties.
+     * and optionally the `delimiter` property.
+     *
+     * @return a map of property keys and values
+     */
+    public Map<String, Object> getProps();
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/TargetType.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/TargetType.java
@@ -11,11 +11,13 @@ public enum TargetType {
     GRAIN("grain"),
     GRAIN_PCRE("grain_pcre"),
     PILLAR("pillar"),
+    PILLAR_EXACT("pillar_exact"),
     PILLAR_PCRE("pillar_pcre"),
     NODEGROUP("nodegroup"),
     RANGE("range"),
     COMPOUND("compound"),
-    IPCIDR("ipcidr");
+    IPCIDR("ipcidr"),
+    DATA("data");
 
     private final String value;
 

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/TargetType.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/TargetType.java
@@ -1,0 +1,25 @@
+package com.suse.salt.netapi.datatypes.target;
+
+/**
+ * Possible values for the tgt_type or expr_form parameter in salt netapi calls.
+ */
+public enum TargetType {
+
+    GLOB("glob"),
+    PCRE("pcre"),
+    LIST("list"),
+    GRAIN("grain"),
+    GRAIN_PCRE("grain_pcre"),
+    PILLAR("pillar"),
+    PILLAR_PCRE("pillar_pcre"),
+    NODEGROUP("nodegroup"),
+    RANGE("range"),
+    COMPOUND("compound"),
+    IPCIDR("ipcidr");
+
+    private final String value;
+
+    TargetType(String value) { this.value = value; }
+
+    public String getValue() { return value; }
+}

--- a/src/test/java/com/suse/salt/netapi/datatypes/target/TargetTypesTest.java
+++ b/src/test/java/com/suse/salt/netapi/datatypes/target/TargetTypesTest.java
@@ -16,12 +16,12 @@ public class TargetTypesTest {
 
     private final String key = "key";
     private final String value = "value";
-    private final char delimiter = DictionaryTargetExpression.DEFAULT_DELIMITER;
+    private final char delimiter = DictionaryTarget.DEFAULT_DELIMITER;
     private final String expr = key + delimiter + value;
 
     @Test
     public void testGrains() {
-        Grains target = new Grains(new DictionaryTargetExpression(expr));
+        Grains target = new Grains(expr);
         assertEquals(TargetType.GRAIN, target.getType());
         dictionaryTargetTestHelper(target);
     }
@@ -35,38 +35,29 @@ public class TargetTypesTest {
 
     @Test
     public void testGrainsRegEx() {
-        GrainsRegEx target = new GrainsRegEx(new DictionaryTargetExpression(expr));
+        GrainsRegEx target = new GrainsRegEx(expr);
         assertEquals(TargetType.GRAIN_PCRE, target.getType());
         dictionaryTargetTestHelper(target);
     }
 
     @Test
     public void testPillar() {
-        Pillar target = new Pillar(new DictionaryTargetExpression(expr));
+        Pillar target = new Pillar(expr);
         assertEquals(TargetType.PILLAR, target.getType());
         dictionaryTargetTestHelper(target);
     }
 
     @Test
     public void testPillarExact() {
-        PillarExact target = new PillarExact(new DictionaryTargetExpression(expr));
+        PillarExact target = new PillarExact(expr);
         assertEquals(TargetType.PILLAR_EXACT, target.getType());
         dictionaryTargetTestHelper(target);
     }
 
     @Test
     public void testPillarRegEx() {
-        PillarRegEx target = new PillarRegEx(new DictionaryTargetExpression(expr));
+        PillarRegEx target = new PillarRegEx(expr);
         assertEquals(TargetType.PILLAR_PCRE, target.getType());
-    }
-
-    @Test
-    public void testAlternateDelimiter() {
-        DictionaryTargetExpression expr = new DictionaryTargetExpression(key, value, '#');
-        Pillar target = new Pillar(expr);
-        assertTrue(target.getProps().containsKey("tgt"));
-        assertTrue(target.getProps().containsKey("expr_form"));
-        assertTrue(target.getProps().containsKey("delimiter"));
     }
 
     @Test

--- a/src/test/java/com/suse/salt/netapi/datatypes/target/TargetTypesTest.java
+++ b/src/test/java/com/suse/salt/netapi/datatypes/target/TargetTypesTest.java
@@ -1,0 +1,136 @@
+package com.suse.salt.netapi.datatypes.target;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Tests for all target types
+ */
+public class TargetTypesTest {
+
+    private final String key = "key";
+    private final String value = "value";
+    private final char delimiter = DictionaryTargetExpression.DEFAULT_DELIMITER;
+    private final String expr = key + delimiter + value;
+
+    @Test
+    public void testGrains() {
+        Grains target = new Grains(new DictionaryTargetExpression(expr));
+        assertEquals(TargetType.GRAIN, target.getType());
+        dictionaryTargetTestHelper(target);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testGrainsDeprecated() {
+        Grains target = new Grains(key, value);
+        assertEquals(key, target.getGrain());
+    }
+
+    @Test
+    public void testGrainsRegEx() {
+        GrainsRegEx target = new GrainsRegEx(new DictionaryTargetExpression(expr));
+        assertEquals(TargetType.GRAIN_PCRE, target.getType());
+        dictionaryTargetTestHelper(target);
+    }
+
+    @Test
+    public void testPillar() {
+        Pillar target = new Pillar(new DictionaryTargetExpression(expr));
+        assertEquals(TargetType.PILLAR, target.getType());
+        dictionaryTargetTestHelper(target);
+    }
+
+    @Test
+    public void testPillarExact() {
+        PillarExact target = new PillarExact(new DictionaryTargetExpression(expr));
+        assertEquals(TargetType.PILLAR_EXACT, target.getType());
+        dictionaryTargetTestHelper(target);
+    }
+
+    @Test
+    public void testPillarRegEx() {
+        PillarRegEx target = new PillarRegEx(new DictionaryTargetExpression(expr));
+        assertEquals(TargetType.PILLAR_PCRE, target.getType());
+    }
+
+    @Test
+    public void testAlternateDelimiter() {
+        DictionaryTargetExpression expr = new DictionaryTargetExpression(key, value, '#');
+        Pillar target = new Pillar(expr);
+        assertTrue(target.getProps().containsKey("tgt"));
+        assertTrue(target.getProps().containsKey("expr_form"));
+        assertTrue(target.getProps().containsKey("delimiter"));
+    }
+
+    @Test
+    public void testCompound() {
+        Compound target = new Compound("*");
+        assertEquals(TargetType.COMPOUND, target.getType());
+    }
+
+    @Test
+    public void testGlob1() {
+        Glob target = Glob.ALL;
+        assertEquals(TargetType.GLOB, target.getType());
+    }
+
+    @Test
+    public void testGlob2() {
+        Glob target = new Glob();
+        assertEquals(TargetType.GLOB, target.getType());
+    }
+
+    @Test
+    public void testIPCidr() {
+        IPCidr target = new IPCidr("0.0.0.0/0");
+        assertEquals(TargetType.IPCIDR, target.getType());
+    }
+
+    @Test
+    public void testNodeGroup() {
+        NodeGroup target = new NodeGroup("group");
+        assertEquals(TargetType.NODEGROUP, target.getType());
+    }
+
+    @Test
+    public void testRange() {
+        Range target = new Range("range");
+        assertEquals(TargetType.RANGE, target.getType());
+    }
+
+    @Test
+    public void testRegEx() {
+        RegEx target = new RegEx(".*");
+        assertEquals(TargetType.PCRE, target.getType());
+    }
+
+    @Test
+    public void testMinionList1() {
+        List<String> minions = Arrays.asList("min1", "min2");
+        MinionList target = new MinionList(minions);
+        assertEquals(TargetType.LIST, target.getType());
+    }
+
+    @Test
+    public void testMinionList2() {
+        MinionList target = new MinionList("min1", "min2");
+        assertEquals(TargetType.LIST, target.getType());
+    }
+
+    private void dictionaryTargetTestHelper(DictionaryTarget target) {
+        assertEquals(expr, target.getTarget());
+        assertEquals(key, target.getKey());
+        assertEquals(value, target.getValue());
+        assertEquals(delimiter, target.getDelimiter());
+        assertTrue(target.getProps().containsKey("tgt"));
+        assertTrue(target.getProps().containsKey("expr_form"));
+        assertFalse(target.getProps().containsKey("delimiter"));
+    }
+}

--- a/src/test/java/com/suse/salt/netapi/datatypes/target/TargetTypesTest.java
+++ b/src/test/java/com/suse/salt/netapi/datatypes/target/TargetTypesTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import java.security.InvalidParameterException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -16,14 +17,36 @@ public class TargetTypesTest {
 
     private final String key = "key";
     private final String value = "value";
-    private final char delimiter = DictionaryTarget.DEFAULT_DELIMITER;
-    private final String expr = key + delimiter + value;
+    private final char alt_delim = '#';
+    private final String def_expr = key + DictionaryTarget.DEFAULT_DELIMITER + value;
+    private final String alt_expr = key + alt_delim + value;
 
     @Test
-    public void testGrains() {
-        Grains target = new Grains(expr);
+    public void testGrains1() {
+        Grains target = new Grains(key, value);
         assertEquals(TargetType.GRAIN, target.getType());
-        dictionaryTargetTestHelper(target);
+        defaultDelimiterTestHelper(target);
+    }
+
+    @Test
+    public void testGrains2() {
+        Grains target = new Grains(key, value, alt_delim);
+        assertEquals(TargetType.GRAIN, target.getType());
+        alternateDelimiterTestHelper(target);
+    }
+
+    @Test
+    public void testGrains3() {
+        Grains target = new Grains(def_expr);
+        assertEquals(TargetType.GRAIN, target.getType());
+        defaultDelimiterTestHelper(target);
+    }
+
+    @Test
+    public void testGrains4() {
+        Grains target = new Grains(alt_expr, alt_delim);
+        assertEquals(TargetType.GRAIN, target.getType());
+        alternateDelimiterTestHelper(target);
     }
 
     @Test
@@ -34,30 +57,115 @@ public class TargetTypesTest {
     }
 
     @Test
-    public void testGrainsRegEx() {
-        GrainsRegEx target = new GrainsRegEx(expr);
+    public void testGrainsRegEx1() {
+        GrainsRegEx target = new GrainsRegEx(key, value);
         assertEquals(TargetType.GRAIN_PCRE, target.getType());
-        dictionaryTargetTestHelper(target);
+        defaultDelimiterTestHelper(target);
     }
 
     @Test
-    public void testPillar() {
-        Pillar target = new Pillar(expr);
+    public void testGrainsRegEx2() {
+        GrainsRegEx target = new GrainsRegEx(key, value, alt_delim);
+        assertEquals(TargetType.GRAIN_PCRE, target.getType());
+        alternateDelimiterTestHelper(target);
+    }
+
+    @Test
+    public void testGrainsRegEx3() {
+        GrainsRegEx target = new GrainsRegEx(def_expr);
+        assertEquals(TargetType.GRAIN_PCRE, target.getType());
+        defaultDelimiterTestHelper(target);
+    }
+
+    @Test
+    public void testGrainsRegEx4() {
+        GrainsRegEx target = new GrainsRegEx(alt_expr, alt_delim);
+        assertEquals(TargetType.GRAIN_PCRE, target.getType());
+        alternateDelimiterTestHelper(target);
+    }
+
+    @Test
+    public void testPillar1() {
+        Pillar target = new Pillar(key, value);
         assertEquals(TargetType.PILLAR, target.getType());
-        dictionaryTargetTestHelper(target);
+        defaultDelimiterTestHelper(target);
     }
 
     @Test
-    public void testPillarExact() {
-        PillarExact target = new PillarExact(expr);
+    public void testPillar2() {
+        Pillar target = new Pillar(key, value, alt_delim);
+        assertEquals(TargetType.PILLAR, target.getType());
+        alternateDelimiterTestHelper(target);
+    }
+
+    @Test
+    public void testPillar3() {
+        Pillar target = new Pillar(def_expr);
+        assertEquals(TargetType.PILLAR, target.getType());
+        defaultDelimiterTestHelper(target);
+    }
+
+    @Test
+    public void testPillar4() {
+        Pillar target = new Pillar(alt_expr, alt_delim);
+        assertEquals(TargetType.PILLAR, target.getType());
+        alternateDelimiterTestHelper(target);
+    }
+
+    @Test
+    public void testPillarExact1() {
+        PillarExact target = new PillarExact(def_expr);
         assertEquals(TargetType.PILLAR_EXACT, target.getType());
-        dictionaryTargetTestHelper(target);
+        defaultDelimiterTestHelper(target);
     }
 
     @Test
-    public void testPillarRegEx() {
-        PillarRegEx target = new PillarRegEx(expr);
+    public void testPillarExact2() {
+        PillarExact target = new PillarExact(alt_expr, alt_delim);
+        assertEquals(TargetType.PILLAR_EXACT, target.getType());
+        alternateDelimiterTestHelper(target);
+    }
+
+    @Test
+    public void testPillarExact3() {
+        PillarExact target = new PillarExact(key, value);
+        assertEquals(TargetType.PILLAR_EXACT, target.getType());
+        defaultDelimiterTestHelper(target);
+    }
+
+    @Test
+    public void testPillarExact4() {
+        PillarExact target = new PillarExact(key, value, alt_delim);
+        assertEquals(TargetType.PILLAR_EXACT, target.getType());
+        alternateDelimiterTestHelper(target);
+    }
+
+    @Test
+    public void testPillarRegEx1() {
+        PillarRegEx target = new PillarRegEx(key, value);
         assertEquals(TargetType.PILLAR_PCRE, target.getType());
+        defaultDelimiterTestHelper(target);
+    }
+
+    @Test
+    public void testPillarRegEx2() {
+        PillarRegEx target = new PillarRegEx(key, value, alt_delim);
+        assertEquals(TargetType.PILLAR_PCRE, target.getType());
+        alternateDelimiterTestHelper(target);
+    }
+
+    @Test
+    public void testPillarRegEx3() {
+        PillarRegEx target = new PillarRegEx(def_expr);
+        assertEquals(TargetType.PILLAR_PCRE, target.getType());
+        defaultDelimiterTestHelper(target);
+    }
+
+    @Test
+    public void testPillarRegEx4() {
+        PillarRegEx target = new PillarRegEx(alt_expr, alt_delim);
+        assertEquals(TargetType.PILLAR_PCRE, target.getType());
+        alternateDelimiterTestHelper(target);
     }
 
     @Test
@@ -115,13 +223,38 @@ public class TargetTypesTest {
         assertEquals(TargetType.LIST, target.getType());
     }
 
-    private void dictionaryTargetTestHelper(DictionaryTarget target) {
-        assertEquals(expr, target.getTarget());
+    @Test(expected = InvalidParameterException.class)
+    public void testInvalidExpression1() {
+        new Grains(":value");
+    }
+
+    @Test(expected = InvalidParameterException.class)
+    public void testInvalidExpression2() {
+        new Grains("value");
+    }
+
+    @Test(expected = InvalidParameterException.class)
+    public void testInvalidExpression3() {
+        new Grains("value:");
+    }
+
+    private void defaultDelimiterTestHelper(DictionaryTarget target) {
+        assertEquals(def_expr, target.getTarget());
         assertEquals(key, target.getKey());
         assertEquals(value, target.getValue());
-        assertEquals(delimiter, target.getDelimiter());
         assertTrue(target.getProps().containsKey("tgt"));
         assertTrue(target.getProps().containsKey("expr_form"));
         assertFalse(target.getProps().containsKey("delimiter"));
+        assertEquals(DictionaryTarget.DEFAULT_DELIMITER, target.getDelimiter());
+    }
+
+    private void alternateDelimiterTestHelper(DictionaryTarget target) {
+        assertEquals(alt_expr, target.getTarget());
+        assertEquals(key, target.getKey());
+        assertEquals(value, target.getValue());
+        assertTrue(target.getProps().containsKey("tgt"));
+        assertTrue(target.getProps().containsKey("expr_form"));
+        assertTrue(target.getProps().containsKey("delimiter"));
+        assertEquals(alt_delim, target.getDelimiter());
     }
 }


### PR DESCRIPTION
This PR addresses #103 by adding support for the following target types:
- pcre
- grain_pcre
- pillar
- pillar_exact
- pillar_pcre
- range
- compound
- ipcidr

It also adds support for special delimiters (other than `:`) in grain and pillar targets, and their variants.