### PR TITLE
Update gson library to recent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.3.1</version>
+      <version>2.8.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/test/java/com/suse/salt/netapi/calls/CallAsyncEventsTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/CallAsyncEventsTest.java
@@ -131,7 +131,7 @@ public class CallAsyncEventsTest extends AbstractEventsTest {
         assertTrue(results.get("minion1").result().get());
 
         assertTrue(results.get("minion2").error().get() instanceof JsonParsingError);
-        assertEquals("Expected BOOLEAN but was STRING",
+        assertEquals("Expected BOOLEAN but was STRING at path $",
                 ((JsonParsingError) results.get("minion2").error().get())
                         .getThrowable().getMessage());
 
@@ -144,7 +144,7 @@ public class CallAsyncEventsTest extends AbstractEventsTest {
         assertTrue(delay23 >= 1000);
 
         assertTrue(results.get("minion4").error().get() instanceof JsonParsingError);
-        assertEquals("Expected BOOLEAN but was STRING", ((JsonParsingError)
+        assertEquals("Expected BOOLEAN but was STRING at path $", ((JsonParsingError)
                 results.get("minion4").error().get()).getThrowable().getMessage());
 
         long delay42 = times.get("minion4") - times.get("minion2");


### PR DESCRIPTION
This patch updates the gson library to a recent version, the version we used seems to be from late 2014! More recent versions bring interesting new features like [alternate serialized names](https://static.javadoc.io/com.google.code.gson/gson/2.8.2/com/google/gson/annotations/SerializedName.html#alternate--) which could be really helpful for implementing compatibility with different versions of an API.