### PR TITLE
Change parameter name: 'expr_form' to 'tgt_type'

### DIFF
--- a/src/main/java/com/suse/salt/netapi/datatypes/target/AbstractTarget.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/AbstractTarget.java
@@ -31,7 +31,7 @@ abstract class AbstractTarget<T> {
     public Map<String, Object> getProps() {
         Map<String, Object> props = new HashMap<>();
         props.put("tgt", getTarget());
-        props.put("expr_form", getType().getValue());
+        props.put("tgt_type", getType().getValue());
         return props;
     }
 }

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/Target.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/Target.java
@@ -25,7 +25,7 @@ public interface Target<T> {
 
     /**
      * Return the properties that belong in a request body.
-     * This will include the `tgt` and `expr_form` properties.
+     * This will include the `tgt` and `tgt_type` properties.
      * and optionally the `delimiter` property.
      *
      * @return a map of property keys and values

--- a/src/main/java/com/suse/salt/netapi/datatypes/target/TargetType.java
+++ b/src/main/java/com/suse/salt/netapi/datatypes/target/TargetType.java
@@ -1,7 +1,7 @@
 package com.suse.salt.netapi.datatypes.target;
 
 /**
- * Possible values for the tgt_type or expr_form parameter in salt netapi calls.
+ * Possible values for the tgt_type parameter in salt netapi calls.
  */
 public enum TargetType {
 

--- a/src/test/java/com/suse/salt/netapi/datatypes/target/TargetTypesTest.java
+++ b/src/test/java/com/suse/salt/netapi/datatypes/target/TargetTypesTest.java
@@ -243,7 +243,7 @@ public class TargetTypesTest {
         assertEquals(key, target.getKey());
         assertEquals(value, target.getValue());
         assertTrue(target.getProps().containsKey("tgt"));
-        assertTrue(target.getProps().containsKey("expr_form"));
+        assertTrue(target.getProps().containsKey("tgt_type"));
         assertFalse(target.getProps().containsKey("delimiter"));
         assertEquals(DictionaryTarget.DEFAULT_DELIMITER, target.getDelimiter());
     }
@@ -253,7 +253,7 @@ public class TargetTypesTest {
         assertEquals(key, target.getKey());
         assertEquals(value, target.getValue());
         assertTrue(target.getProps().containsKey("tgt"));
-        assertTrue(target.getProps().containsKey("expr_form"));
+        assertTrue(target.getProps().containsKey("tgt_type"));
         assertTrue(target.getProps().containsKey("delimiter"));
         assertEquals(alt_delim, target.getDelimiter());
     }

--- a/src/test/resources/async_via_event_test_ping_request.json
+++ b/src/test/resources/async_via_event_test_ping_request.json
@@ -3,6 +3,6 @@
     "tgt": "*",
     "client": "local_async",
     "fun": "test.ping",
-    "expr_form": "glob"
+    "tgt_type": "glob"
   }
 ]

--- a/src/test/resources/call_sync_batch_ping_request.json
+++ b/src/test/resources/call_sync_batch_ping_request.json
@@ -3,7 +3,7 @@
     "tgt": "*",
     "eauth": "auto",
     "password": "pa55wd",
-    "expr_form": "glob",
+    "tgt_type": "glob",
     "batch": "1",
     "client": "local_batch",
     "fun": "test.ping",

--- a/src/test/resources/call_sync_ping_request.json
+++ b/src/test/resources/call_sync_ping_request.json
@@ -3,7 +3,7 @@
     "tgt": "*",
     "eauth": "auto",
     "password": "pa55wd",
-    "expr_form": "glob",
+    "tgt_type": "glob",
     "client": "local",
     "fun": "test.ping",
     "username": "user"

--- a/src/test/resources/minions_request.json
+++ b/src/test/resources/minions_request.json
@@ -1,6 +1,6 @@
 [
   {
-    "expr_form": "glob",
+    "tgt_type": "glob",
     "tgt": "*",
     "fun": "pkg.install",
     "arg": ["i3"],
@@ -10,4 +10,3 @@
     }
   }
 ]
-

--- a/src/test/resources/run_request.json
+++ b/src/test/resources/run_request.json
@@ -4,7 +4,7 @@
     "password": "pass",
     "eauth": "pam",
     "client": "local",
-    "expr_form": "glob",
+    "tgt_type": "glob",
     "tgt": "*",
     "fun": "pkg.install",
     "arg": ["i3"],

--- a/src/test/resources/ssh_ping_request.json
+++ b/src/test/resources/ssh_ping_request.json
@@ -1,6 +1,6 @@
 [
   {
-    "expr_form": "glob",
+    "tgt_type": "glob",
     "tgt": "*",
     "client": "ssh",
     "fun": "test.ping",

--- a/src/test/resources/ssh_raw_run_request.json
+++ b/src/test/resources/ssh_raw_run_request.json
@@ -2,7 +2,7 @@
   {
     "client": "ssh",
     "tgt": "*",
-    "expr_form": "glob",
+    "tgt_type": "glob",
     "raw_shell": true,
     "fun": "uptime"
   }


### PR DESCRIPTION
This patch is to fix #227: `expr_form` is deprecated and will be replaced with `tgt_type` everywhere.