### PR TITLE
Enable "Pkg.InfoInstalled" to return all installed package versions

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/modules/Pkg.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/Pkg.java
@@ -264,15 +264,14 @@ public class Pkg {
      *
      * @param attributes list of attributes that should be included in the result
      * @param reportErrors if true will return an error message instead of corrupted text
-     * @param allVersions if true will return all installed package versions, not only latest
      * @param packages optional give package names, otherwise return info about all packages
      * @return the call
      */
-    public static LocalCall<Map<String, Xor<Info, List<Info>>>> infoInstalled(List<String> attributes,
-            boolean reportErrors, boolean allVersions, String... packages) {
+    public static LocalCall<Map<String, Xor<Info, List<Info>>>> infoInstalledAllVersions(
+            List<String> attributes, boolean reportErrors, String... packages) {
         LinkedHashMap<String, Object> kwargs = new LinkedHashMap<>();
         kwargs.put("attr", attributes.stream().collect(Collectors.joining(",")));
-        kwargs.put("all_versions", allVersions);
+        kwargs.put("all_versions", true);
         if (reportErrors) {
             kwargs.put("errors", "report");
         }

--- a/src/main/java/com/suse/salt/netapi/calls/modules/Pkg.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/Pkg.java
@@ -259,6 +259,27 @@ public class Pkg {
                 Optional.of(kwargs), new TypeToken<Map<String, Info>>(){});
     }
 
+    /**
+     * Call 'pkg.info_installed' API.
+     *
+     * @param attributes list of attributes that should be included in the result
+     * @param reportErrors if true will return an error message instead of corrupted text
+     * @param allVersions if true will return all installed package versions, not only latest
+     * @param packages optional give package names, otherwise return info about all packages
+     * @return the call
+     */
+    public static LocalCall<Map<String, Xor<Info, List<Info>>>> infoInstalled(List<String> attributes,
+            boolean reportErrors, boolean allVersions, String... packages) {
+        LinkedHashMap<String, Object> kwargs = new LinkedHashMap<>();
+        kwargs.put("attr", attributes.stream().collect(Collectors.joining(",")));
+        kwargs.put("all_versions", allVersions);
+        if (reportErrors) {
+            kwargs.put("errors", "report");
+        }
+        return new LocalCall<>("pkg.info_installed", Optional.of(Arrays.asList(packages)),
+                Optional.of(kwargs), new TypeToken<Map<String, Xor<Info, List<Info>>>>(){});
+    }
+
     public static LocalCall<Map<String, Info>> infoAvailable(String... packages) {
         return new LocalCall<>("pkg.info_available", Optional.of(Arrays.asList(packages)),
                 Optional.empty(), new TypeToken<Map<String, Info>>(){});

--- a/src/test/java/com/suse/salt/netapi/calls/modules/PkgTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/PkgTest.java
@@ -67,21 +67,9 @@ public class PkgTest {
     }
 
     @Test
-    public void testInfoInstalledAllVersionsFalse() {
-        TypeToken<Map<String, Xor<Pkg.Info, List<Pkg.Info>>>> type = Pkg.infoInstalled(
-                new ArrayList<>(), false, false, "vim").getReturnType();
-        InputStream is = this.getClass()
-                .getResourceAsStream("/modules/pkg/info_installed.json");
-        JsonParser<Map<String, Xor<Pkg.Info, List<Pkg.Info>>>> parser = new JsonParser<>(type);
-        Map<String, Xor<Pkg.Info, List<Pkg.Info>>> parsed = parser.parse(is);
-        Pkg.Info info = parsed.get("vim").left().get();
-        assertEquals(Optional.of("x86_64"), info.getArchitecture());
-    }
-
-    @Test
-    public void testInfoInstalledAllVersionsTrue() {
-        TypeToken<Map<String, Xor<Pkg.Info, List<Pkg.Info>>>> type = Pkg.infoInstalled(
-                new ArrayList<>(), false, true, "vim").getReturnType();
+    public void testInfoInstalledAllVersions() {
+        TypeToken<Map<String, Xor<Pkg.Info, List<Pkg.Info>>>> type =
+                Pkg.infoInstalledAllVersions(new ArrayList<>(), false, "vim").getReturnType();
         InputStream is = this.getClass()
                 .getResourceAsStream("/modules/pkg/info_installed_full.json");
         JsonParser<Map<String, Xor<Pkg.Info, List<Pkg.Info>>>> parser = new JsonParser<>(type);

--- a/src/test/java/com/suse/salt/netapi/calls/modules/PkgTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/PkgTest.java
@@ -67,6 +67,31 @@ public class PkgTest {
     }
 
     @Test
+    public void testInfoInstalledAllVersionsFalse() {
+        TypeToken<Map<String, Xor<Pkg.Info, List<Pkg.Info>>>> type = Pkg.infoInstalled(
+                new ArrayList<>(), false, false, "vim").getReturnType();
+        InputStream is = this.getClass()
+                .getResourceAsStream("/modules/pkg/info_installed.json");
+        JsonParser<Map<String, Xor<Pkg.Info, List<Pkg.Info>>>> parser = new JsonParser<>(type);
+        Map<String, Xor<Pkg.Info, List<Pkg.Info>>> parsed = parser.parse(is);
+        Pkg.Info info = parsed.get("vim").left().get();
+        assertEquals(Optional.of("x86_64"), info.getArchitecture());
+    }
+
+    @Test
+    public void testInfoInstalledAllVersionsTrue() {
+        TypeToken<Map<String, Xor<Pkg.Info, List<Pkg.Info>>>> type = Pkg.infoInstalled(
+                new ArrayList<>(), false, true, "vim").getReturnType();
+        InputStream is = this.getClass()
+                .getResourceAsStream("/modules/pkg/info_installed_full.json");
+        JsonParser<Map<String, Xor<Pkg.Info, List<Pkg.Info>>>> parser = new JsonParser<>(type);
+        Map<String, Xor<Pkg.Info, List<Pkg.Info>>> parsed = parser.parse(is);
+        List<Pkg.Info> infoList = parsed.get("vim").right().get();
+        assertEquals(Optional.of("x86_64"), infoList.get(0).getArchitecture());
+        assertEquals(Optional.of("i686"), infoList.get(1).getArchitecture());
+    }
+
+    @Test
     public void testUpgradeAvailable() {
         TypeToken<Boolean> type = Pkg.upgradeAvailable("cloud-init").getReturnType();
         InputStream is = this.getClass()

--- a/src/test/resources/modules/pkg/info_installed_full.json
+++ b/src/test/resources/modules/pkg/info_installed_full.json
@@ -1,0 +1,44 @@
+{
+  "vim": [
+    {
+        "build_date": "2014-10-08T03:44:36Z",
+        "group": "Productivity/Editors/Vi",
+        "name": "vim",
+        "license": "Vim",
+        "build_host": "sheep21",
+        "url": "http://www.vim.org/",
+        "relocations": "(not relocatable)",
+        "install_date": "2015-08-24T05:58:22Z",
+        "summary": "Vi IMproved",
+        "source": "vim-7.4.326-2.62.src.rpm",
+        "version": "7.4.326",
+        "arch": "x86_64",
+        "signature": "RSA/SHA256, Wed 08 Oct 2014 03:45:49 PM UTC, Key ID 70af9e8139db7c82",
+        "release": "2.62",
+        "vendor": "SUSE LLC <https://www.suse.com/>",
+        "packager": "https://www.suse.com/",
+        "description": "Vim (Vi IMproved) is an almost compatible version of the UNIX editor\nvi. Almost every possible command can be performed using only ASCII\ncharacters. Only the 'Q' command is missing (you do not need it). Many\nnew features have been added: multilevel undo, command line history,\nfile name completion, block operations, and editing of binary data.\n\nVi is available for the AMIGA, MS-DOS, Windows NT, and various versions\nof UNIX.\n\nFor SUSE Linux, Vim is used as /usr/bin/vi.",
+        "size": "2714880"
+    },
+    {
+        "build_date": "2014-10-08T03:44:36Z",
+        "group": "Productivity/Editors/Vi",
+        "name": "vim",
+        "license": "Vim",
+        "build_host": "sheep21",
+        "url": "http://www.vim.org/",
+        "relocations": "(not relocatable)",
+        "install_date": "2015-08-24T05:58:22Z",
+        "summary": "Vi IMproved",
+        "source": "vim-7.4.326-2.62.src.rpm",
+        "version": "7.4.326",
+        "arch": "i686",
+        "signature": "RSA/SHA256, Wed 08 Oct 2014 03:45:49 PM UTC, Key ID 70af9e8139db7c82",
+        "release": "2.62",
+        "vendor": "SUSE LLC <https://www.suse.com/>",
+        "packager": "https://www.suse.com/",
+        "description": "Vim (Vi IMproved) is an almost compatible version of the UNIX editor\nvi. Almost every possible command can be performed using only ASCII\ncharacters. Only the 'Q' command is missing (you do not need it). Many\nnew features have been added: multilevel undo, command line history,\nfile name completion, block operations, and editing of binary data.\n\nVi is available for the AMIGA, MS-DOS, Windows NT, and various versions\nof UNIX.\n\nFor SUSE Linux, Vim is used as /usr/bin/vi.",
+        "size": "2714880"
+    }
+  ]
+}


### PR DESCRIPTION
This PR enables `Pkg.InfoInstalled` call to get all installed package versions on the minion (instead only the latest version) by introducing the `allVersions` parameter for `Pkg.InfoInstalled`.

Salt `all_versions` parameter for `pkg.info_installed` has been introduced here: https://github.com/saltstack/salt/pull/47678 (approved but not yet merged)

