### PR TITLE
EventStream refactoring

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -11,7 +11,7 @@ import com.suse.salt.netapi.datatypes.Event;
 import com.suse.salt.netapi.datatypes.target.Target;
 import com.suse.salt.netapi.errors.GenericError;
 import com.suse.salt.netapi.event.EventListener;
-import com.suse.salt.netapi.event.EventStream;
+import com.suse.salt.netapi.event.WebSocketEventStream;
 import com.suse.salt.netapi.event.JobReturnEvent;
 import com.suse.salt.netapi.event.RunnerReturnEvent;
 import com.suse.salt.netapi.results.Result;
@@ -159,7 +159,7 @@ public class LocalCall<R> extends AbstractCall<R> {
             String username,
             String password,
             AuthModule authModule,
-            EventStream events,
+            WebSocketEventStream events,
             CompletionStage<GenericError> cancel) {
         return callAsync(
                 localCall -> localCall.callAsync(client, target, username,
@@ -184,7 +184,7 @@ public class LocalCall<R> extends AbstractCall<R> {
     public CompletionStage<Map<String, CompletionStage<Result<R>>>> callAsync(
             SaltClient client,
             Target<?> target,
-            EventStream events,
+            WebSocketEventStream events,
             CompletionStage<GenericError> cancel) {
         return callAsync(
                 localCall -> localCall.callAsync(client, target),
@@ -208,7 +208,7 @@ public class LocalCall<R> extends AbstractCall<R> {
             Function<LocalCall<R>, CompletionStage<LocalAsyncResult<R>>> localAsync,
             Function<RunnerCall<Map<String, R>>,
                                 CompletionStage<RunnerAsyncResult<Map<String, R>>>> runnerAsync,
-            EventStream events,
+            WebSocketEventStream events,
             CompletionStage<GenericError> cancel) {
 
         return localAsync.apply(this).thenApply(lar -> {

--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -11,7 +11,7 @@ import com.suse.salt.netapi.datatypes.Event;
 import com.suse.salt.netapi.datatypes.target.Target;
 import com.suse.salt.netapi.errors.GenericError;
 import com.suse.salt.netapi.event.EventListener;
-import com.suse.salt.netapi.event.WebSocketEventStream;
+import com.suse.salt.netapi.event.EventStream;
 import com.suse.salt.netapi.event.JobReturnEvent;
 import com.suse.salt.netapi.event.RunnerReturnEvent;
 import com.suse.salt.netapi.results.Result;
@@ -159,7 +159,7 @@ public class LocalCall<R> extends AbstractCall<R> {
             String username,
             String password,
             AuthModule authModule,
-            WebSocketEventStream events,
+            EventStream events,
             CompletionStage<GenericError> cancel) {
         return callAsync(
                 localCall -> localCall.callAsync(client, target, username,
@@ -184,7 +184,7 @@ public class LocalCall<R> extends AbstractCall<R> {
     public CompletionStage<Map<String, CompletionStage<Result<R>>>> callAsync(
             SaltClient client,
             Target<?> target,
-            WebSocketEventStream events,
+            EventStream events,
             CompletionStage<GenericError> cancel) {
         return callAsync(
                 localCall -> localCall.callAsync(client, target),
@@ -208,7 +208,7 @@ public class LocalCall<R> extends AbstractCall<R> {
             Function<LocalCall<R>, CompletionStage<LocalAsyncResult<R>>> localAsync,
             Function<RunnerCall<Map<String, R>>,
                                 CompletionStage<RunnerAsyncResult<Map<String, R>>>> runnerAsync,
-            WebSocketEventStream events,
+            EventStream events,
             CompletionStage<GenericError> cancel) {
 
         return localAsync.apply(this).thenApply(lar -> {

--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -21,7 +21,6 @@ import com.suse.salt.netapi.results.SSHResult;
 import com.google.gson.reflect.TypeToken;
 import com.suse.salt.netapi.utils.ClientUtils;
 
-import javax.websocket.CloseReason;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.List;
@@ -241,11 +240,11 @@ public class LocalCall<R> extends AbstractCall<R> {
                 }
 
                 @Override
-                public void eventStreamClosed(CloseReason closeReason) {
+                public void eventStreamClosed(int code, String phrase) {
                     Result<R> error = Result.error(
                             new GenericError(
                                     "EventStream closed with reason "
-                                            + closeReason));
+                                            + phrase));
                     futures.values().forEach(f -> f.complete(error));
                 }
             };

--- a/src/main/java/com/suse/salt/netapi/client/SaltClient.java
+++ b/src/main/java/com/suse/salt/netapi/client/SaltClient.java
@@ -12,7 +12,7 @@ import com.suse.salt.netapi.datatypes.Token;
 import com.suse.salt.netapi.datatypes.cherrypy.Stats;
 import com.suse.salt.netapi.datatypes.target.Target;
 import com.suse.salt.netapi.event.EventListener;
-import com.suse.salt.netapi.event.EventStream;
+import com.suse.salt.netapi.event.WebSocketEventStream;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.parser.JsonParser;
 import com.suse.salt.netapi.results.SSHRawResult;
@@ -228,7 +228,7 @@ public class SaltClient implements AutoCloseable {
      * Returns a WebSocket @ClientEndpoint annotated object connected
      * to the /ws ServerEndpoint.
      * <p>
-     * The stream object supports the {@link EventStream} interface which allows the caller
+     * The stream object supports the {@link WebSocketEventStream} interface which allows the caller
      * to register/unregister for stream event notifications as well as close the event
      * stream.
      * <p>
@@ -241,8 +241,8 @@ public class SaltClient implements AutoCloseable {
      * @return the event stream
      * @throws SaltException in case of an error during websocket stream initialization
      */
-    public EventStream events(EventListener... listeners) throws SaltException {
-        return new EventStream(config, listeners);
+    public WebSocketEventStream events(EventListener... listeners) throws SaltException {
+        return new WebSocketEventStream(config, listeners);
     }
 
     /**

--- a/src/main/java/com/suse/salt/netapi/event/AbstractEventStream.java
+++ b/src/main/java/com/suse/salt/netapi/event/AbstractEventStream.java
@@ -67,7 +67,9 @@ public abstract class AbstractEventStream implements EventStream {
      */
     protected void notifyListeners(Event event) {
         synchronized (listeners) {
-            listeners.forEach(l -> l.notify(event));
+            for (EventListener listener : new ArrayList<>(listeners)) {
+                listener.notify(event);
+            }
         }
     }
 

--- a/src/main/java/com/suse/salt/netapi/event/AbstractEventStream.java
+++ b/src/main/java/com/suse/salt/netapi/event/AbstractEventStream.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2018 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.salt.netapi.event;
+
+import com.suse.salt.netapi.datatypes.Event;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Implements basic listener bookkeeping for EventStream.
+ */
+public abstract class AbstractEventStream implements EventStream {
+
+    /**
+     * Listeners that are notified of a new events.
+     */
+    private final List<EventListener> listeners = new ArrayList<>();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addEventListener(EventListener listener) {
+        synchronized (listeners) {
+            listeners.add(listener);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeEventListener(EventListener listener) {
+        synchronized (listeners) {
+            listeners.remove(listener);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getListenerCount() {
+        synchronized (listeners) {
+            return listeners.size();
+        }
+    }
+
+    /**
+     * Notifies all listeners of an event
+     *
+     * @param event the event
+     */
+    protected void notifyListeners(Event event) {
+        synchronized (listeners) {
+            listeners.forEach(l -> l.notify(event));
+        }
+    }
+
+    /**
+     * Removes all listeners.
+     *
+     * @param code an integer code to represent the reason for closing
+     * @param phrase a String representation of code
+     */
+    protected void clearListeners(int code, String phrase) {
+        synchronized (listeners) {
+            listeners.forEach(listener -> listener.eventStreamClosed(code, phrase));
+
+            // Clear out the listeners
+            listeners.clear();
+        }
+    }
+}

--- a/src/main/java/com/suse/salt/netapi/event/EventListener.java
+++ b/src/main/java/com/suse/salt/netapi/event/EventListener.java
@@ -2,8 +2,6 @@ package com.suse.salt.netapi.event;
 
 import com.suse.salt.netapi.datatypes.Event;
 
-import javax.websocket.CloseReason;
-
 /**
  * Defines a client notification interface for events stream.
  */
@@ -18,7 +16,8 @@ public interface EventListener {
     /**
      * Notify the listener that the backing event stream was closed.  Listener may
      * need to recreate the event stream or take other actions.
-     * @param closeReason the close reason
+     * @param code an integer code to represent the reason for closing
+     * @param phrase a String representation of code
      */
-    void eventStreamClosed(CloseReason closeReason);
+    void eventStreamClosed(int code, String phrase);
 }

--- a/src/main/java/com/suse/salt/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/salt/netapi/event/EventStream.java
@@ -169,7 +169,7 @@ public class EventStream implements AutoCloseable {
      * @param closeReason the reason for the websocket closure
      * @throws IOException in case of an error when closing the session
      */
-    public void close(CloseReason closeReason) throws IOException {
+    private void close(CloseReason closeReason) throws IOException {
         if (!isEventStreamClosed()) {
             session.close(closeReason);
         }

--- a/src/main/java/com/suse/salt/netapi/event/EventStream.java
+++ b/src/main/java/com/suse/salt/netapi/event/EventStream.java
@@ -1,0 +1,49 @@
+package com.suse.salt.netapi.event;
+
+import com.suse.salt.netapi.datatypes.Event;
+
+import java.io.IOException;
+
+/**
+ * Represents a container of listener to {@link Event}; for each message a bunch of
+ * {@link EventListener} will be recalled and notified with it.
+ */
+public interface EventStream extends AutoCloseable {
+
+    /**
+     * Adds a listener.
+     *
+     * @param listener Reference to the class that implements {@link EventListener}.
+     */
+    void addEventListener(EventListener listener);
+
+    /**
+     * Removes a listener.
+     *
+     * @param listener Reference to the class that implements {@link EventListener}.
+     */
+    void removeEventListener(EventListener listener);
+
+    /**
+     * Helper method that returns the current number of subscribed listeners.
+     *
+     * @return The current number listeners.
+     */
+    int getListenerCount();
+
+    /**
+     * Helper method to check if the stream is able to receive Events.
+     *
+     * @return A flag indicating the Stream state.
+     */
+    boolean isEventStreamClosed();
+
+    /**
+     * Closes this Stream; Events will not be posted to listeners after this call.
+     *
+     * @throws IOException in case of an error when closing the session
+     */
+    @Override
+    void close() throws IOException;
+
+}

--- a/src/main/java/com/suse/salt/netapi/event/WebSocketEventStream.java
+++ b/src/main/java/com/suse/salt/netapi/event/WebSocketEventStream.java
@@ -31,11 +31,10 @@ import java.util.stream.Collectors;
 /**
  * Event stream implementation based on a {@link ClientEndpoint} WebSocket.
  * It is used to connect the WebSocket to a {@link ServerEndpoint}
- * and receive messages from it; for each message a bunch of {@link EventListener}
- * will be recalled and notified with it.
+ * and receive messages from it.
  */
 @ClientEndpoint
-public class WebSocketEventStream implements AutoCloseable {
+public class WebSocketEventStream implements EventStream {
 
     /**
      * Listeners that are notified of a new events.
@@ -110,10 +109,9 @@ public class WebSocketEventStream implements AutoCloseable {
     }
 
     /**
-     * Implementation of {@link WebSocketEventStream#addEventListener(EventListener)}
-     *
-     * @param listener Reference to the class that implements {@link EventListener}.
+     * {@inheritDoc}
      */
+    @Override
     public void addEventListener(EventListener listener) {
         synchronized (listeners) {
             listeners.add(listener);
@@ -121,10 +119,9 @@ public class WebSocketEventStream implements AutoCloseable {
     }
 
     /**
-     * Implementation of {@link WebSocketEventStream#removeEventListener(EventListener)}.
-     *
-     * @param listener Reference to the class that implements {@link EventListener}.
+     * {@inheritDoc}
      */
+    @Override
     public void removeEventListener(EventListener listener) {
         synchronized (listeners) {
             listeners.remove(listener);
@@ -132,10 +129,9 @@ public class WebSocketEventStream implements AutoCloseable {
     }
 
     /**
-     * Helper method that returns the current number of subscribed listeners.
-     *
-     * @return The current number listeners.
+     * {@inheritDoc}
      */
+    @Override
     public int getListenerCount() {
         synchronized (listeners) {
             return listeners.size();
@@ -143,19 +139,15 @@ public class WebSocketEventStream implements AutoCloseable {
     }
 
     /**
-     * Helper method to check if the WebSocket Session exists and is open.
-     *
-     * @return A flag indicating the {@link WebSocketEventStream}
-     * WebSocket {@link Session} state.
+     * {@inheritDoc}
      */
+    @Override
     public boolean isEventStreamClosed() {
         return this.session == null || !this.session.isOpen();
     }
 
     /**
-     * Close the WebSocket {@link Session}.
-     *
-     * @throws IOException in case of an error when closing the session
+     * {@inheritDoc}
      */
     @Override
     public void close() throws IOException {

--- a/src/main/java/com/suse/salt/netapi/event/WebSocketEventStream.java
+++ b/src/main/java/com/suse/salt/netapi/event/WebSocketEventStream.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
  * will be recalled and notified with it.
  */
 @ClientEndpoint
-public class EventStream implements AutoCloseable {
+public class WebSocketEventStream implements AutoCloseable {
 
     /**
      * Listeners that are notified of a new events.
@@ -76,7 +76,7 @@ public class EventStream implements AutoCloseable {
      * @param listeners event listeners to be added before stream initialization
      * @throws SaltException in case of an error during stream initialization
      */
-    public EventStream(ClientConfig config, EventListener... listeners)
+    public WebSocketEventStream(ClientConfig config, EventListener... listeners)
             throws SaltException {
         maxMessageLength = config.get(ClientConfig.WEBSOCKET_MAX_MESSAGE_LENGTH) > 0 ?
                 config.get(ClientConfig.WEBSOCKET_MAX_MESSAGE_LENGTH) : Integer.MAX_VALUE;
@@ -110,7 +110,7 @@ public class EventStream implements AutoCloseable {
     }
 
     /**
-     * Implementation of {@link EventStream#addEventListener(EventListener)}
+     * Implementation of {@link WebSocketEventStream#addEventListener(EventListener)}
      *
      * @param listener Reference to the class that implements {@link EventListener}.
      */
@@ -121,7 +121,7 @@ public class EventStream implements AutoCloseable {
     }
 
     /**
-     * Implementation of {@link EventStream#removeEventListener(EventListener)}.
+     * Implementation of {@link WebSocketEventStream#removeEventListener(EventListener)}.
      *
      * @param listener Reference to the class that implements {@link EventListener}.
      */
@@ -145,7 +145,7 @@ public class EventStream implements AutoCloseable {
     /**
      * Helper method to check if the WebSocket Session exists and is open.
      *
-     * @return A flag indicating the {@link EventStream}
+     * @return A flag indicating the {@link WebSocketEventStream}
      * WebSocket {@link Session} state.
      */
     public boolean isEventStreamClosed() {

--- a/src/main/java/com/suse/salt/netapi/event/WebSocketEventStream.java
+++ b/src/main/java/com/suse/salt/netapi/event/WebSocketEventStream.java
@@ -250,7 +250,9 @@ public class WebSocketEventStream implements EventStream {
 
         // Notify all the listeners and cleanup
         synchronized (listeners) {
-            listeners.stream().forEach(listener -> listener.eventStreamClosed(closeReason));
+            int code = closeReason.getCloseCode().getCode();
+            String phrase = closeReason.getReasonPhrase();
+            listeners.stream().forEach(l -> l.eventStreamClosed(code, phrase));
 
             // Clear out the listeners
             listeners.clear();

--- a/src/test/java/com/suse/salt/netapi/calls/CallAsyncEventsTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/CallAsyncEventsTest.java
@@ -8,6 +8,7 @@ import com.suse.salt.netapi.errors.GenericError;
 import com.suse.salt.netapi.errors.JsonParsingError;
 import com.suse.salt.netapi.event.WebSocketEventStream;
 import com.suse.salt.netapi.event.AbstractEventsTest;
+import com.suse.salt.netapi.event.EventStream;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.utils.ClientUtils;
@@ -100,7 +101,7 @@ public class CallAsyncEventsTest extends AbstractEventsTest {
                         .withBody(json("/async_via_event_list_job_response.json"))));
 
 
-        WebSocketEventStream events = new WebSocketEventStream(clientConfig);
+        EventStream events = new WebSocketEventStream(clientConfig);
 
         Map<String, CompletionStage<Result<Boolean>>> call =
                 com.suse.salt.netapi.calls.modules.Test.ping().callAsync(

--- a/src/test/java/com/suse/salt/netapi/calls/CallAsyncEventsTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/CallAsyncEventsTest.java
@@ -6,7 +6,7 @@ import com.suse.salt.netapi.client.SaltClient;
 import com.suse.salt.netapi.datatypes.target.Glob;
 import com.suse.salt.netapi.errors.GenericError;
 import com.suse.salt.netapi.errors.JsonParsingError;
-import com.suse.salt.netapi.event.EventStream;
+import com.suse.salt.netapi.event.WebSocketEventStream;
 import com.suse.salt.netapi.event.AbstractEventsTest;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.results.Result;
@@ -100,7 +100,7 @@ public class CallAsyncEventsTest extends AbstractEventsTest {
                         .withBody(json("/async_via_event_list_job_response.json"))));
 
 
-        EventStream events = new EventStream(clientConfig);
+        WebSocketEventStream events = new WebSocketEventStream(clientConfig);
 
         Map<String, CompletionStage<Result<Boolean>>> call =
                 com.suse.salt.netapi.calls.modules.Test.ping().callAsync(

--- a/src/test/java/com/suse/salt/netapi/event/TyrusWebSocketEventsTest.java
+++ b/src/test/java/com/suse/salt/netapi/event/TyrusWebSocketEventsTest.java
@@ -6,7 +6,6 @@ import com.suse.salt.netapi.datatypes.Event;
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.websocket.CloseReason;
 import javax.websocket.CloseReason.CloseCodes;
 import java.util.ArrayList;
 import java.util.List;
@@ -94,10 +93,10 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
         WebSocketEventStream streamEvents = new WebSocketEventStream(clientConfig, eventListener);
         streamEvents.close();
         Assert.assertTrue(streamEvents.isEventStreamClosed());
-        Assert.assertEquals(CloseCodes.GOING_AWAY,
-                eventListener.closeReason.getCloseCode());
+        Assert.assertEquals(CloseCodes.GOING_AWAY.getCode(),
+                eventListener.closeCode);
         String message = "The listener has closed the event stream";
-        Assert.assertEquals(message, eventListener.closeReason.getReasonPhrase());
+        Assert.assertEquals(message, eventListener.closePhrase);
     }
 
     /**
@@ -131,11 +130,11 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
         try (EventStream streamEvents = new WebSocketEventStream(clientConfig, eventListener)) {
             latch.await(30, TimeUnit.SECONDS);
             Assert.assertTrue(streamEvents.isEventStreamClosed());
-            Assert.assertEquals(CloseCodes.TOO_BIG,
-                    eventListener.closeReason.getCloseCode());
+            Assert.assertEquals(CloseCodes.TOO_BIG.getCode(),
+                    eventListener.closeCode);
             String message = "Message length exceeded the configured maximum (" +
                     maxMessageLength + " characters)";
-            Assert.assertEquals(message, eventListener.closeReason.getReasonPhrase());
+            Assert.assertEquals(message, eventListener.closePhrase);
         }
     }
 
@@ -161,7 +160,7 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
         }
 
         @Override
-        public void eventStreamClosed(CloseReason closeReason) {
+        public void eventStreamClosed(int code, String phrase) {
         }
     }
 
@@ -187,7 +186,7 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
         }
 
         @Override
-        public void eventStreamClosed(CloseReason closeReason) {
+        public void eventStreamClosed(int code, String phrase) {
         }
     }
 
@@ -195,15 +194,17 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
      * Simple Event ListenerClient
      */
     private class SimpleEventListenerClient implements EventListener {
-        CloseReason closeReason;
+        int closeCode;
+        String closePhrase;
 
         @Override
         public void notify(Event event) {
         }
 
         @Override
-        public void eventStreamClosed(CloseReason closeReason) {
-            this.closeReason = closeReason;
+        public void eventStreamClosed(int code, String phrase) {
+            this.closeCode = code;
+            this.closePhrase = phrase;
         }
     }
 
@@ -212,7 +213,8 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
      */
     private class EventStreamClosedClient implements EventListener {
         private final CountDownLatch latch;
-        CloseReason closeReason;
+        int closeCode;
+        String closePhrase;
 
         public EventStreamClosedClient(CountDownLatch latchIn) {
             this.latch = latchIn;
@@ -224,8 +226,9 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
         }
 
         @Override
-        public void eventStreamClosed(CloseReason closeReason) {
-            this.closeReason = closeReason;
+        public void eventStreamClosed(int code, String phrase) {
+            this.closeCode = code;
+            this.closePhrase = phrase;
             this.latch.countDown();
         }
     }

--- a/src/test/java/com/suse/salt/netapi/event/TyrusWebSocketEventsTest.java
+++ b/src/test/java/com/suse/salt/netapi/event/TyrusWebSocketEventsTest.java
@@ -35,7 +35,7 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
         CountDownLatch latch = new CountDownLatch(1);
         EventCountClient eventCountClient = new EventCountClient(target, latch);
 
-        try (EventStream streamEvents = new EventStream(clientConfig, eventCountClient)) {
+        try (WebSocketEventStream streamEvents = new WebSocketEventStream(clientConfig, eventCountClient)) {
             latch.await(30, TimeUnit.SECONDS);
             Assert.assertTrue(eventCountClient.counter == target);
         }
@@ -51,7 +51,7 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
         CountDownLatch latch = new CountDownLatch(1);
         EventContentClient eventContentClient = new EventContentClient(latch);
 
-        try (EventStream streamEvents = new EventStream(clientConfig, eventContentClient)) {
+        try (WebSocketEventStream streamEvents = new WebSocketEventStream(clientConfig, eventContentClient)) {
             latch.await(30, TimeUnit.SECONDS);
             synchronized (eventContentClient.events) {
                 Event event = eventContentClient.events.get(1);
@@ -73,7 +73,7 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
         SimpleEventListenerClient client3 = new SimpleEventListenerClient();
         SimpleEventListenerClient client4 = new SimpleEventListenerClient();
 
-        try (EventStream streamEvents = new EventStream(clientConfig, client1, client2)) {
+        try (WebSocketEventStream streamEvents = new WebSocketEventStream(clientConfig, client1, client2)) {
             streamEvents.addEventListener(client3);
             streamEvents.removeEventListener(client2);
             streamEvents.removeEventListener(client3);
@@ -91,7 +91,7 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
     @Test
     public void testEventProcessingStateStopped() throws Exception {
         SimpleEventListenerClient eventListener = new SimpleEventListenerClient();
-        EventStream streamEvents = new EventStream(clientConfig, eventListener);
+        WebSocketEventStream streamEvents = new WebSocketEventStream(clientConfig, eventListener);
         streamEvents.close();
         Assert.assertTrue(streamEvents.isEventStreamClosed());
         Assert.assertEquals(CloseCodes.GOING_AWAY,
@@ -110,7 +110,7 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
         CountDownLatch latch = new CountDownLatch(1);
         EventStreamClosedClient eventListener = new EventStreamClosedClient(latch);
 
-        try (EventStream streamEvents = new EventStream(clientConfig, eventListener)) {
+        try (WebSocketEventStream streamEvents = new WebSocketEventStream(clientConfig, eventListener)) {
             latch.await(30, TimeUnit.SECONDS);
             Assert.assertFalse(streamEvents.isEventStreamClosed());
         }
@@ -128,7 +128,7 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
         CountDownLatch latch = new CountDownLatch(1);
         EventStreamClosedClient eventListener = new EventStreamClosedClient(latch);
 
-        try (EventStream streamEvents = new EventStream(clientConfig, eventListener)) {
+        try (WebSocketEventStream streamEvents = new WebSocketEventStream(clientConfig, eventListener)) {
             latch.await(30, TimeUnit.SECONDS);
             Assert.assertTrue(streamEvents.isEventStreamClosed());
             Assert.assertEquals(CloseCodes.TOO_BIG,

--- a/src/test/java/com/suse/salt/netapi/event/TyrusWebSocketEventsTest.java
+++ b/src/test/java/com/suse/salt/netapi/event/TyrusWebSocketEventsTest.java
@@ -35,7 +35,7 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
         CountDownLatch latch = new CountDownLatch(1);
         EventCountClient eventCountClient = new EventCountClient(target, latch);
 
-        try (WebSocketEventStream streamEvents = new WebSocketEventStream(clientConfig, eventCountClient)) {
+        try (EventStream streamEvents = new WebSocketEventStream(clientConfig, eventCountClient)) {
             latch.await(30, TimeUnit.SECONDS);
             Assert.assertTrue(eventCountClient.counter == target);
         }
@@ -51,7 +51,7 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
         CountDownLatch latch = new CountDownLatch(1);
         EventContentClient eventContentClient = new EventContentClient(latch);
 
-        try (WebSocketEventStream streamEvents = new WebSocketEventStream(clientConfig, eventContentClient)) {
+        try (EventStream streamEvents = new WebSocketEventStream(clientConfig, eventContentClient)) {
             latch.await(30, TimeUnit.SECONDS);
             synchronized (eventContentClient.events) {
                 Event event = eventContentClient.events.get(1);
@@ -73,7 +73,7 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
         SimpleEventListenerClient client3 = new SimpleEventListenerClient();
         SimpleEventListenerClient client4 = new SimpleEventListenerClient();
 
-        try (WebSocketEventStream streamEvents = new WebSocketEventStream(clientConfig, client1, client2)) {
+        try (EventStream streamEvents = new WebSocketEventStream(clientConfig, client1, client2)) {
             streamEvents.addEventListener(client3);
             streamEvents.removeEventListener(client2);
             streamEvents.removeEventListener(client3);
@@ -110,7 +110,7 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
         CountDownLatch latch = new CountDownLatch(1);
         EventStreamClosedClient eventListener = new EventStreamClosedClient(latch);
 
-        try (WebSocketEventStream streamEvents = new WebSocketEventStream(clientConfig, eventListener)) {
+        try (EventStream streamEvents = new WebSocketEventStream(clientConfig, eventListener)) {
             latch.await(30, TimeUnit.SECONDS);
             Assert.assertFalse(streamEvents.isEventStreamClosed());
         }
@@ -128,7 +128,7 @@ public class TyrusWebSocketEventsTest extends AbstractEventsTest {
         CountDownLatch latch = new CountDownLatch(1);
         EventStreamClosedClient eventListener = new EventStreamClosedClient(latch);
 
-        try (WebSocketEventStream streamEvents = new WebSocketEventStream(clientConfig, eventListener)) {
+        try (EventStream streamEvents = new WebSocketEventStream(clientConfig, eventListener)) {
             latch.await(30, TimeUnit.SECONDS);
             Assert.assertTrue(streamEvents.isEventStreamClosed());
             Assert.assertEquals(CloseCodes.TOO_BIG,

--- a/src/test/java/com/suse/salt/netapi/examples/Events.java
+++ b/src/test/java/com/suse/salt/netapi/examples/Events.java
@@ -6,7 +6,7 @@ import com.suse.salt.netapi.config.ClientConfig;
 import com.suse.salt.netapi.datatypes.Event;
 import com.suse.salt.netapi.datatypes.Token;
 import com.suse.salt.netapi.event.EventListener;
-import com.suse.salt.netapi.event.EventStream;
+import com.suse.salt.netapi.event.WebSocketEventStream;
 
 import java.net.URI;
 
@@ -32,7 +32,7 @@ public class Events {
             System.out.println("Token: " + token.getToken());
 
             // Init the event stream with a basic listener implementation
-            EventStream eventStream = client.events(new EventListener() {
+            WebSocketEventStream eventStream = client.events(new EventListener() {
                 @Override
                 public void notify(Event e) {
                     System.out.println("Tag  -> " + e.getTag());

--- a/src/test/java/com/suse/salt/netapi/examples/Events.java
+++ b/src/test/java/com/suse/salt/netapi/examples/Events.java
@@ -10,8 +10,6 @@ import com.suse.salt.netapi.event.WebSocketEventStream;
 
 import java.net.URI;
 
-import javax.websocket.CloseReason;
-
 /**
  * Example code listening for events on salt's event bus.
  */
@@ -40,9 +38,8 @@ public class Events {
                 }
 
                 @Override
-                public void eventStreamClosed(CloseReason closeReason) {
-                    System.out.println("Event stream closed: " +
-                            closeReason.getReasonPhrase());
+                public void eventStreamClosed(int code, String phrase) {
+                    System.out.println("Event stream closed: " + phrase);
                 }
             });
 


### PR DESCRIPTION
This is a set of 5 refactorings to detach `EventStream` from its WebSocket implementation and allow alternative implementations.

This is needed in order to replace reading from WebSockets completely in Uyuni where we plan to read them from a Postgres database filled by a custom Salt Engine.

Best reviewed commit-by-commit.