### PR TITLE
Enable working with API served on a sub-path

### DIFF
--- a/src/main/java/com/suse/salt/netapi/event/WebSocketEventStream.java
+++ b/src/main/java/com/suse/salt/netapi/event/WebSocketEventStream.java
@@ -77,7 +77,7 @@ public class WebSocketEventStream extends AbstractEventStream {
         maxMessageLength = maxMsgSize > 0 ?
                 maxMsgSize : Integer.MAX_VALUE;
         Arrays.asList(listeners).forEach(this::addEventListener);
-        initializeStream(uri, token, sessionIdleTimeout, idleTimeout);
+        initializeStream(uri.resolve("/"), token, sessionIdleTimeout, idleTimeout);
     }
 
     /**
@@ -90,7 +90,7 @@ public class WebSocketEventStream extends AbstractEventStream {
         try {
             URI adjustedURI = new URI(uri.getScheme() == "https" ? "wss" : "ws",
                     uri.getSchemeSpecificPart(), uri.getFragment())
-                    .resolve("/ws/" + token.getToken());
+                    .resolve("ws/" + token.getToken());
             websocketContainer.setDefaultMaxSessionIdleTimeout(sessionIdleTimeout);
 
             // Initiate the websocket handshake


### PR DESCRIPTION
This should fix #237 by removing leading slashes from API endpoints when calling `uri.resolve()`. The base URL now requires to have a trailing slash, so we add it in case it does not.

@danh-fissara, it would be great if you could give this a try so we know that it solves your problem. Thanks!