### PR TITLE
Build and run tests with oraclejdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk9
+  - oraclejdk11
 
 services:
   - docker


### PR DESCRIPTION
This patch changes the travis configuration (`.travis.yml`) to build and test the code with `oraclejdk8` and `oraclejdk11`.