### PR TITLE
Use OpenJDK (8 and 11) in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: required
 language: java
 jdk:
-  - oraclejdk8
-  - oraclejdk11
+  - openjdk8
+  - openjdk11
 
 services:
   - docker

--- a/scripts/publish_javadoc.sh
+++ b/scripts/publish_javadoc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ "$TRAVIS_JDK_VERSION" == "oraclejdk8"  &&  "$TRAVIS_PULL_REQUEST" == "false"  &&  ("$TRAVIS_BRANCH" == "master" || "$TRAVIS_TAG") ]]; then
+if [[ "$TRAVIS_JDK_VERSION" == "openjdk11"  &&  "$TRAVIS_PULL_REQUEST" == "false"  &&  ("$TRAVIS_BRANCH" == "master" || "$TRAVIS_TAG") ]]; then
 
   cp -R target/site/apidocs $HOME/javadoc-latest
 


### PR DESCRIPTION
This patch is updating `.travis.yml` to build the library with `openjdk8` and `openjdk11` in Travis CI. Javadoc would always be published from the `openjdk11` build on `master` branch.