### PR TITLE
Change empty strings to optional.empty

### DIFF
--- a/src/main/java/com/suse/salt/netapi/parser/OptionalTypeAdapterFactory.java
+++ b/src/main/java/com/suse/salt/netapi/parser/OptionalTypeAdapterFactory.java
@@ -1,8 +1,11 @@
 package com.suse.salt.netapi.parser;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.internal.bind.TypeAdapters;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
@@ -41,8 +44,24 @@ public class OptionalTypeAdapterFactory implements TypeAdapterFactory {
                     in.nextNull();
                     return Optional.empty();
                 } else {
-                    A value = innerAdapter.read(in);
-                    return Optional.of(value);
+                    JsonElement json = TypeAdapters.JSON_ELEMENT.read(in);
+                    try {
+                        A value = innerAdapter.fromJsonTree(json);
+                        return Optional.of(value);
+                    }
+                    catch (JsonSyntaxException e) {
+                        /**
+                         * Note : This is a workaround and it only exists because salt doesn't differentiate between a
+                         * non-existent grain and a grain which exists but has value set to empty String.
+                         *
+                         * If an object is expected but instead empty string comes in then we return empty Optional.
+                         */
+                        if (json.isJsonPrimitive() && json.getAsJsonPrimitive().isString() &&
+                                json.getAsString().isEmpty()) {
+                            return Optional.empty();
+                        }
+                        throw e;
+                    }
                 }
             }
 


### PR DESCRIPTION
Salt return empty string for non-existent grains, if user expects an Optional<object> instead, GSON cannot parse it. in such cases return Optional.empty.