### PR TITLE
bring auth modules up to date with current salt docs

### DIFF
--- a/src/main/java/com/suse/salt/netapi/AuthModule.java
+++ b/src/main/java/com/suse/salt/netapi/AuthModule.java
@@ -9,12 +9,14 @@ public enum AuthModule {
 
     AUTO("auto"),
     DJANGO("django"),
+    FILE("file"),
     KEYSTONE("keystone"),
     LDAP("ldap"),
     MYSQL("mysql"),
     PAM("pam"),
     PKI("pki"),
-    STORMPATH_MOD("stormpath_mod"),
+    REST("rest"),
+    SHAREDSECRET("sharedsecret"),
     YUBICO("yubico");
 
     private final String value;


### PR DESCRIPTION
removes old modules that don't exist anymore and adds all currently documented ones.