### PR TITLE
Fix type mismatch error with Eclipse and VS Code

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -379,7 +379,7 @@ public class LocalCall<R> extends AbstractCall<R> {
     private List<Map<String, Result<R>>> handleRetcodeBatchingHack(List<Map<String, Result<R>>> list, Type xor) {
         return list.stream().map(m -> {
             return m.entrySet().stream().collect(Collectors.toMap(e -> e.getKey(), e -> {
-                return e.getValue().fold(err -> {
+                return e.getValue().<Result<R>>fold(err -> {
                     return err.<Result<R>>fold(
                             Result::error,
                             Result::error,


### PR DESCRIPTION
This patch is needed to make the current `master` branch compile in Eclipse as well as in VS Code, where apparently the same compiler is used. This is the error message that I see there:

```
Type mismatch: cannot convert from List<Map<String,Object>> to List<Map<String,Result<R>>>
```