### PR TITLE
Feat: add pkg.list_patterns call

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/modules/Pkg.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/Pkg.java
@@ -204,6 +204,28 @@ public class Pkg {
         }
     }
 
+    /**
+     * Information about a pattern as returned by "pkg.list_patterns".
+     */
+    public static class PatternInfo {
+
+        private String summary;
+        private boolean installed;
+
+        public String getSummary() {
+            return summary;
+        }
+
+        public boolean isInstalled() {
+            return installed;
+        }
+
+        @Override
+        public String toString() {
+            return "{Summary: " + summary + ", installed: " + installed + "}";
+        }
+    }
+
     private Pkg() { }
 
     public static LocalCall<Map<String, PackageInfo>> search(String criteria) {
@@ -384,6 +406,19 @@ public class Pkg {
         return new LocalCall<>("pkg.latest_version",
                 Optional.of(Arrays.asList(firstPackageName, secondPackageName, packages)),
                 Optional.empty(), new TypeToken<Map<String, String>>(){});
+    }
+
+    /**
+     * Call 'pkg.list_patterns' via Salt API.
+     *
+     * @param refresh refresh repos
+     * @return the call. Only returns a populated map for SUSE-based distros using zypper
+     */
+    public static LocalCall<Optional<Map<String, PatternInfo>>> listPatterns(boolean refresh) {
+        LinkedHashMap<String, Object> kwargs = new LinkedHashMap<>();
+        kwargs.put("refresh", refresh);
+        return new LocalCall<>("pkg.list_patterns", Optional.empty(),
+                Optional.of(kwargs), new TypeToken<Optional<Map<String, PatternInfo>>>(){});
     }
 
     /**

--- a/src/main/java/com/suse/salt/netapi/calls/modules/Pkg.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/Pkg.java
@@ -2,6 +2,7 @@ package com.suse.salt.netapi.calls.modules;
 
 import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.results.Change;
+import com.suse.salt.netapi.results.PatternInfo;
 import com.suse.salt.netapi.utils.Xor;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
@@ -201,28 +202,6 @@ public class Pkg {
                     .collect(Collectors.joining(","));
 
             return "Info(" + fields + ")";
-        }
-    }
-
-    /**
-     * Information about a pattern as returned by "pkg.list_patterns".
-     */
-    public static class PatternInfo {
-
-        private String summary;
-        private boolean installed;
-
-        public String getSummary() {
-            return summary;
-        }
-
-        public boolean isInstalled() {
-            return installed;
-        }
-
-        @Override
-        public String toString() {
-            return "{Summary: " + summary + ", installed: " + installed + "}";
         }
     }
 

--- a/src/main/java/com/suse/salt/netapi/results/PatternInfo.java
+++ b/src/main/java/com/suse/salt/netapi/results/PatternInfo.java
@@ -1,0 +1,22 @@
+package com.suse.salt.netapi.results;
+
+/**
+ * Information about a pattern as returned by "pkg.list_patterns".
+ */
+public class PatternInfo {
+    private String summary;
+    private boolean installed;
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public boolean isInstalled() {
+        return installed;
+    }
+
+    @Override
+    public String toString() {
+        return "{Summary: " + summary + ", installed: " + installed + "}";
+    }
+}

--- a/src/test/java/com/suse/salt/netapi/calls/modules/PkgTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/PkgTest.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Pkg unit tests.
@@ -160,5 +161,20 @@ public class PkgTest {
         assertEquals(Optional.of("4.8.11-2.110"), actualNew.getVersion());
         assertEquals(Optional.of(1500308350L), actualNew.getInstallDateUnixTime());
         assertEquals(Optional.of("x86_64"), actualNew.getArchitecture());
+    }
+
+    @Test
+    public void testListPatterns() {
+        TypeToken<Optional<Map<String, Pkg.PatternInfo>>> type = Pkg.listPatterns(false).getReturnType();
+        InputStream is = this.getClass()
+                .getResourceAsStream("/modules/pkg/list_patterns.json");
+        JsonParser<Optional<Map<String, Pkg.PatternInfo>>> parser =
+                new JsonParser<>(type);
+        Optional<Map<String, Pkg.PatternInfo>> parsed = parser.parse(is);
+        parsed.ifPresent(pattern -> {
+            assertTrue(pattern.get("base").isInstalled());
+            assertFalse(pattern.get("32bit").isInstalled());
+            assertEquals("Help and Support Documentation", pattern.get("documentation").getSummary());
+        });
     }
 }

--- a/src/test/java/com/suse/salt/netapi/calls/modules/PkgTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/PkgTest.java
@@ -1,12 +1,15 @@
 package com.suse.salt.netapi.calls.modules;
 
+import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.google.gson.reflect.TypeToken;
 import com.suse.salt.netapi.calls.modules.Pkg.Info;
 import com.suse.salt.netapi.parser.JsonParser;
 import com.suse.salt.netapi.results.Change;
+import com.suse.salt.netapi.results.PatternInfo;
 import com.suse.salt.netapi.utils.Xor;
 
 import org.junit.Test;
@@ -19,9 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Pkg unit tests.
@@ -165,12 +165,12 @@ public class PkgTest {
 
     @Test
     public void testListPatterns() {
-        TypeToken<Optional<Map<String, Pkg.PatternInfo>>> type = Pkg.listPatterns(false).getReturnType();
+        TypeToken<Optional<Map<String, PatternInfo>>> type = Pkg.listPatterns(false).getReturnType();
         InputStream is = this.getClass()
                 .getResourceAsStream("/modules/pkg/list_patterns.json");
-        JsonParser<Optional<Map<String, Pkg.PatternInfo>>> parser =
+        JsonParser<Optional<Map<String, PatternInfo>>> parser =
                 new JsonParser<>(type);
-        Optional<Map<String, Pkg.PatternInfo>> parsed = parser.parse(is);
+        Optional<Map<String, PatternInfo>> parsed = parser.parse(is);
         parsed.ifPresent(pattern -> {
             assertTrue(pattern.get("base").isInstalled());
             assertFalse(pattern.get("32bit").isInstalled());

--- a/src/test/resources/modules/pkg/list_patterns.json
+++ b/src/test/resources/modules/pkg/list_patterns.json
@@ -1,0 +1,102 @@
+{
+    "32bit": {
+        "installed": false,
+        "summary": "32-Bit Runtime Environment"
+    },
+    "apparmor": {
+        "installed": false,
+        "summary": "AppArmor"
+    },
+    "base": {
+        "installed": true,
+        "summary": "Minimal Base System"
+    },
+    "common-criteria": {
+        "installed": false,
+        "summary": "Tools and scripts for Common Criteria"
+    },
+    "dhcp_dns_server": {
+        "installed": false,
+        "summary": "DHCP and DNS Server"
+    },
+    "directory_server": {
+        "installed": false,
+        "summary": "Directory Server (LDAP)"
+    },
+    "documentation": {
+        "installed": false,
+        "summary": "Help and Support Documentation"
+    },
+    "enhanced_base": {
+        "installed": false,
+        "summary": "Enhanced Base System"
+    },
+    "file_server": {
+        "installed": false,
+        "summary": "File Server"
+    },
+    "fips": {
+        "installed": false,
+        "summary": "FIPS 140-2 specific packages"
+    },
+    "fonts": {
+        "installed": false,
+        "summary": "Fonts"
+    },
+    "gateway_server": {
+        "installed": false,
+        "summary": "Internet Gateway"
+    },
+    "kvm_server": {
+        "installed": false,
+        "summary": "KVM Host Server"
+    },
+    "kvm_tools": {
+        "installed": false,
+        "summary": "KVM Virtualization Host and tools"
+    },
+    "lamp_server": {
+        "installed": false,
+        "summary": "Web and LAMP Server"
+    },
+    "mail_server": {
+        "installed": false,
+        "summary": "Mail and News Server"
+    },
+    "ofed": {
+        "installed": false,
+        "summary": "Infiniband (OFED)"
+    },
+    "oracle_server": {
+        "installed": false,
+        "summary": "Oracle Server Base"
+    },
+    "print_server": {
+        "installed": false,
+        "summary": "Print Server"
+    },
+    "sap_server": {
+        "installed": false,
+        "summary": "SAP Application Server Base"
+    },
+    "sw_management": {
+        "installed": false,
+        "summary": "Software Management"
+    },
+    "x11": {
+        "installed": false,
+        "summary": "X Window System"
+    },
+    "xen_server": {
+        "installed": false,
+        "summary": "Xen Virtual Machine Host Server"
+    },
+    "xen_tools": {
+        "installed": false,
+        "summary": "XEN Virtualization Host and tools"
+    },
+    "yast2_basis": {
+        "installed": false,
+        "summary": "YaST System Administration"
+    }
+}


### PR DESCRIPTION
This PR adds support for calling `pkg.list_patterns`: https://docs.saltproject.io/en/latest/ref/modules/all/salt.modules.zypperpkg.html#module-salt.modules.zypperpkg

The `list_patterns` is only implemented by the `zypperpkg` "child" execution module of `pkg`: this is why the call returns an `Optional` map.

JUnit tests added.