### PR TITLE
add saltssherror for better error reporting

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -396,6 +396,7 @@ public class LocalCall<R> extends AbstractCall<R> {
                                     return Result.error(parsingError);
                                 }
                             },
+                            Result::error,
                             Result::error
                     );
                 }, Result::success);

--- a/src/main/java/com/suse/salt/netapi/errors/FunctionNotAvailable.java
+++ b/src/main/java/com/suse/salt/netapi/errors/FunctionNotAvailable.java
@@ -20,7 +20,8 @@ final public class FunctionNotAvailable implements SaltError {
     public <T> T fold(Function<FunctionNotAvailable, ? extends T> fnNotAvail,
             Function<ModuleNotSupported, ? extends T> modNotSupported,
             Function<JsonParsingError, ? extends T> jsonError,
-            Function<GenericError, ? extends T> generic
+            Function<GenericError, ? extends T> generic,
+            Function<SaltSSHError, ? extends T> saltSshError
     ) {
         return fnNotAvail.apply(this);
     }

--- a/src/main/java/com/suse/salt/netapi/errors/GenericError.java
+++ b/src/main/java/com/suse/salt/netapi/errors/GenericError.java
@@ -22,7 +22,9 @@ final public class GenericError implements SaltError {
     public <T> T fold(Function<FunctionNotAvailable, ? extends T> fnNotAvail,
             Function<ModuleNotSupported, ? extends T> modNotSupported,
             Function<JsonParsingError, ? extends T> jsonError,
-            Function<GenericError, ? extends T> generic) {
+            Function<GenericError, ? extends T> generic,
+            Function<SaltSSHError, ? extends T> saltSshError
+    ) {
         return generic.apply(this);
     }
 

--- a/src/main/java/com/suse/salt/netapi/errors/JsonParsingError.java
+++ b/src/main/java/com/suse/salt/netapi/errors/JsonParsingError.java
@@ -33,7 +33,8 @@ final public class JsonParsingError implements SaltError {
     public <T> T fold(Function<FunctionNotAvailable, ? extends T> fnNotAvail,
             Function<ModuleNotSupported, ? extends T> modNotSupported,
             Function<JsonParsingError, ? extends T> jsonError,
-            Function<GenericError, ? extends T> generic
+            Function<GenericError, ? extends T> generic,
+            Function<SaltSSHError, ? extends T> saltSshError
     ) {
         return jsonError.apply(this);
     }

--- a/src/main/java/com/suse/salt/netapi/errors/ModuleNotSupported.java
+++ b/src/main/java/com/suse/salt/netapi/errors/ModuleNotSupported.java
@@ -25,7 +25,8 @@ final public class ModuleNotSupported implements SaltError {
     public <T> T fold(Function<FunctionNotAvailable, ? extends T> fnNotAvail,
             Function<ModuleNotSupported, ? extends T> modNotSupported,
             Function<JsonParsingError, ? extends T> jsonError,
-            Function<GenericError, ? extends T> generic
+            Function<GenericError, ? extends T> generic,
+            Function<SaltSSHError, ? extends T> saltSshError
     ) {
         return modNotSupported.apply(this);
     }

--- a/src/main/java/com/suse/salt/netapi/errors/SaltError.java
+++ b/src/main/java/com/suse/salt/netapi/errors/SaltError.java
@@ -10,7 +10,8 @@ public interface SaltError {
     <T> T fold(Function<FunctionNotAvailable, ? extends T> fnNotAvail,
             Function<ModuleNotSupported, ? extends T> modNotSupported,
             Function<JsonParsingError, ? extends T> jsonError,
-            Function<GenericError, ? extends T> generic);
+            Function<GenericError, ? extends T> generic,
+            Function<SaltSSHError, ? extends T> saltSshError);
 
 }
 

--- a/src/main/java/com/suse/salt/netapi/errors/SaltSSHError.java
+++ b/src/main/java/com/suse/salt/netapi/errors/SaltSSHError.java
@@ -1,0 +1,40 @@
+package com.suse.salt.netapi.errors;
+
+import java.util.function.Function;
+
+/**
+ * Interface for all salt related errors
+ */
+public class SaltSSHError implements SaltError {
+
+    private final int retcode;
+    private final String message;
+
+    public SaltSSHError(int retcode, String message) {
+        this.message = message;
+        this.retcode = retcode;
+    }
+
+    @Override
+    public String toString() {
+        return "SaltSSHError(" + getRetcode() + ", " + getMessage() + ")";
+    }
+
+    public int getRetcode() {
+        return retcode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public <T> T fold(Function<FunctionNotAvailable, ? extends T> fnNotAvail,
+                      Function<ModuleNotSupported, ? extends T> modNotSupported,
+                      Function<JsonParsingError, ? extends T> jsonError,
+                      Function<GenericError, ? extends T> generic,
+                      Function<SaltSSHError, ? extends T> saltSshError) {
+        return saltSshError.apply(this);
+    }
+
+}
+


### PR DESCRIPTION
This adds a generic salt ssh error that will forward retcode and stderr returned in the salt ssh result in case the retcode is not 0.