### PR TITLE
StateApplyResult: enable arrays for name field

### DIFF
--- a/src/main/java/com/suse/salt/netapi/results/StateApplyResult.java
+++ b/src/main/java/com/suse/salt/netapi/results/StateApplyResult.java
@@ -10,7 +10,7 @@ import com.google.gson.annotations.SerializedName;
 public class StateApplyResult<R> {
 
     private String comment;
-    private String name;
+    private Object name;
     @SerializedName("start_time")
     private String startTime;
     private boolean result;
@@ -24,7 +24,7 @@ public class StateApplyResult<R> {
     }
 
     public String getName() {
-        return name;
+        return name.toString();
     }
 
     public String getStartTime() {


### PR DESCRIPTION
Provides more flexibility at small cost in situations where mapping JSON responses to Java objects, where name field contains an Array of a single String element, fails. 
