### PR TITLE
Use "stdout" as error message for SaltSSHError in cases where "stderr" is empty

### DIFF
--- a/src/main/java/com/suse/salt/netapi/parser/ResultSSHResultTypeAdapterFactory.java
+++ b/src/main/java/com/suse/salt/netapi/parser/ResultSSHResultTypeAdapterFactory.java
@@ -85,7 +85,8 @@ public class ResultSSHResultTypeAdapterFactory implements TypeAdapterFactory {
                                         .flatMap(SaltErrorUtils::deriveError)
                                         .orElse(
                                                 new SaltSSHError(result.getRetcode(),
-                                                        result.getStderr().orElse(result.getStdout().orElse("")))
+							"stderr: \"" + result.getStderr().orElse("") +
+                                                        "\", stdout: \"" + result.getStdout().orElse("") + "\"")
                                         )
                         );
                     } else {

--- a/src/main/java/com/suse/salt/netapi/parser/ResultSSHResultTypeAdapterFactory.java
+++ b/src/main/java/com/suse/salt/netapi/parser/ResultSSHResultTypeAdapterFactory.java
@@ -85,7 +85,7 @@ public class ResultSSHResultTypeAdapterFactory implements TypeAdapterFactory {
                                         .flatMap(SaltErrorUtils::deriveError)
                                         .orElse(
                                                 new SaltSSHError(result.getRetcode(),
-                                                        result.getStderr().orElse(""))
+                                                        result.getStderr().orElse(result.getStdout().orElse("")))
                                         )
                         );
                     } else {


### PR DESCRIPTION
This PR makes `SaltSSHError` to use `stdout` as error message in cases where the Salt SSH execution produces an error event with empty `stderr` but containing meaningful data in the `stdout`:

```json
{"uyuni-master-min-sles15.mgr.suse.de": {"stdout": "\rPassword: \nError: Wrong number of arguments!\n", "stderr": "", "retcode": 255, "id": "uyuni-master-min-sles15.mgr.suse.de", "fun": "state.apply", "jid": "20220303090427537110", "_stamp": "2022-03-03T09:04:30.263709"}}
```

We noticed this happening in some ocassions, specially when using "preflight script" on salt ssh, where `SaltSSHError` was raised without no message:

![image](https://user-images.githubusercontent.com/7229203/156540449-f167337f-cb47-491a-816c-1f2db7440e30.png)

