### PR TITLE
make reboot always a direct_call

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/modules/System.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/System.java
@@ -4,6 +4,7 @@ import com.suse.salt.netapi.calls.LocalCall;
 
 import com.google.gson.reflect.TypeToken;
 
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Optional;
 
@@ -21,7 +22,8 @@ public class System {
         at_time.ifPresent(t -> {
             args.put("at_time", t);
         });
-        return new LocalCall<>("system.reboot", Optional.empty(), Optional.of(args),
+        return new LocalCall<>("system.reboot", Optional.of(Arrays.asList("--module-executors=['direct_call']")),
+                Optional.of(args),
                 new TypeToken<String>(){});
     }
 }


### PR DESCRIPTION
Currently any reboot action is not executed in SLE Micro. The reason is due to the fact that any salt state is executed as a transactional update and it's not possible to execute a reboot in a transaction. These changes make any reboot actions use a `direct_call` executor.

Fixes https://github.com/SUSE/spacewalk/issues/18381