### PR TITLE
Update JDK and maven plugin versions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,9 +26,9 @@ jobs:
         options: --name saltminion2 --link saltmaster:salt
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '11'
@@ -36,11 +36,11 @@ jobs:
         run: mvn checkstyle:check javadoc:javadoc test package
       - name: Get branch name or tag
         if: success()
-        uses: tj-actions/branch-names@v5
+        uses: tj-actions/branch-names@v8
         id: branch-name
       - name: Publish javadoc for the default branch
         if: success() && steps.branch-name.outputs.is_default == 'true'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/apidocs
@@ -49,7 +49,7 @@ jobs:
           user_email: 'github-actions[bot]@users.noreply.github.com'
       - name: Publish javadoc for a tagged release
         if: success() && steps.branch-name.outputs.is_tag == 'true'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/apidocs

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
+        <version>1.6.13</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>
@@ -51,7 +51,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.6</version>
+        <version>3.2.4</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>
@@ -65,7 +65,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.3.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -78,7 +78,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.13.0</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -87,7 +87,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.6.3</version>
         <configuration>
             <source>8</source>
         </configuration>
@@ -103,7 +103,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.3.1</version>
         <dependencies>
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
@@ -123,7 +123,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.2.5</version>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -79,9 +79,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.13.0</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+	<configuration>
+          <release>11</release>
         </configuration>
       </plugin>
       <plugin>
@@ -89,7 +88,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.6.3</version>
         <configuration>
-            <source>8</source>
+            <source>11</source>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
This PR is about updating `pom.xml` and the GitHub Actions workflow (`maven.yml`):

- Update maven plugins to their latest versions
- Update GitHub Actions to their latest versions
- Update the JDK version (from 1.8 to 11, using [`release`](https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html) instead of `source` and `target`) and implementation (see [all supported distributions](https://github.com/actions/setup-java?tab=readme-ov-file#supported-distributions))