### PR TITLE
implement withExecutors for LocalCall

### DIFF
--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -44,31 +44,36 @@ public class LocalCall<R> extends AbstractCall<R> {
     private final Optional<?> metadata;
     private final Optional<Integer> timeout;
     private final Optional<Integer> gatherJobTimeout;
+    private final Optional<List<String>> executors;
+    private final Optional<Map<String, ?>> executorOptions;
 
     public LocalCall(String functionName, Optional<List<?>> arg,
             Optional<Map<String, ?>> kwarg, TypeToken<R> returnType,
             Optional<?> metadata, Optional<Integer> timeout,
-            Optional<Integer> gatherJobTimeout) {
+            Optional<Integer> gatherJobTimeout, Optional<List<String>> executors,
+            Optional<Map<String, ?>> executorOptions) {
         super(functionName, returnType);
         this.arg = arg;
         this.kwarg = kwarg;
         this.metadata = metadata;
         this.timeout = timeout;
         this.gatherJobTimeout = gatherJobTimeout;
+        this.executors = executors;
+        this.executorOptions = executorOptions;
     }
 
     public LocalCall(String functionName, Optional<List<?>> arg,
             Optional<Map<String, ?>> kwarg, TypeToken<R> returnType,
             Optional<Integer> timeout, Optional<Integer> gatherJobTimeout) {
         this(functionName, arg, kwarg, returnType, Optional.empty(),
-                timeout, gatherJobTimeout);
+                timeout, gatherJobTimeout, Optional.empty(), Optional.empty());
     }
 
     public LocalCall(String functionName, Optional<List<?>> arg,
             Optional<Map<String, ?>> kwarg, TypeToken<R> returnType,
             Optional<?> metadata) {
         this(functionName, arg, kwarg, returnType, metadata, Optional.empty(),
-                Optional.empty());
+                Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     public LocalCall(String functionName, Optional<List<?>> arg,
@@ -78,23 +83,34 @@ public class LocalCall<R> extends AbstractCall<R> {
 
     public LocalCall<R> withMetadata(Object metadata) {
         return new LocalCall<>(getFunction(), arg, kwarg, getReturnType(),
-                Optional.of(metadata), timeout, gatherJobTimeout);
+                Optional.of(metadata), timeout, gatherJobTimeout, executors, executorOptions);
     }
 
     public LocalCall<R> withoutMetadata() {
         return new LocalCall<>(getFunction(), arg, kwarg, getReturnType(),
-                Optional.empty(), timeout, gatherJobTimeout);
+                Optional.empty(), timeout, gatherJobTimeout, executors, executorOptions);
     }
 
     public LocalCall<R> withTimeouts(Optional<Integer> timeout,
             Optional<Integer> gatherJobTimeout) {
         return new LocalCall<>(getFunction(), arg, kwarg, getReturnType(), metadata,
-                timeout, gatherJobTimeout);
+                timeout, gatherJobTimeout, executors, executorOptions);
     }
 
     public LocalCall<R> withoutTimeouts() {
         return new LocalCall<>(getFunction(), arg, kwarg, getReturnType(), metadata,
-                Optional.empty(), Optional.empty());
+                Optional.empty(), Optional.empty(), executors, executorOptions);
+    }
+
+    public LocalCall<R> withExecutors(Optional<List<String>> executors,
+                                     Optional<Map<String, ?>> executorOptions) {
+        return new LocalCall<>(getFunction(), arg, kwarg, getReturnType(), metadata,
+                timeout, gatherJobTimeout, executors, executorOptions);
+    }
+
+    public LocalCall<R> withoutExecutors() {
+        return new LocalCall<>(getFunction(), arg, kwarg, getReturnType(), metadata,
+                timeout, gatherJobTimeout, Optional.empty(), Optional.empty());
     }
 
     /**
@@ -110,6 +126,8 @@ public class LocalCall<R> extends AbstractCall<R> {
         timeout.ifPresent(timeout -> payload.put("timeout", timeout));
         gatherJobTimeout.ifPresent(gatherJobTimeout -> payload.put("gather_job_timeout",
                 gatherJobTimeout));
+        executors.ifPresent(exe -> payload.put("module_executors", exe));
+        executorOptions.ifPresent(opts -> payload.put("executor_opts", opts));
         return payload;
     }
 

--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -63,6 +63,14 @@ public class LocalCall<R> extends AbstractCall<R> {
     }
 
     public LocalCall(String functionName, Optional<List<?>> arg,
+                     Optional<Map<String, ?>> kwarg, TypeToken<R> returnType,
+                     Optional<?> metadata, Optional<Integer> timeout,
+                     Optional<Integer> gatherJobTimeout) {
+        this(functionName, arg, kwarg, returnType, metadata, timeout, gatherJobTimeout,
+                Optional.empty(), Optional.empty());
+    }
+
+    public LocalCall(String functionName, Optional<List<?>> arg,
             Optional<Map<String, ?>> kwarg, TypeToken<R> returnType,
             Optional<Integer> timeout, Optional<Integer> gatherJobTimeout) {
         this(functionName, arg, kwarg, returnType, Optional.empty(),

--- a/src/test/java/com/suse/salt/netapi/calls/LocalCallTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/LocalCallTest.java
@@ -38,6 +38,8 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -122,6 +124,34 @@ public class LocalCallTest {
         assertEquals(runWithTimeouts.getPayload().get("timeout"), 4);
         assertEquals(runWithTimeouts.getPayload().get("gather_job_timeout"), 1);
     }
+
+    @Test
+    public void testWithExecutors() {
+        LocalCall<String> run = Cmd.run("echo 'hello world'");
+        assertFalse(run.getPayload().containsKey("module_executors"));
+        assertFalse(run.getPayload().containsKey("executor_opts"));
+
+        LocalCall<String> runWithExecutors = run.withExecutors(Optional.of(List.of("direct_call")), Optional.empty());
+        assertTrue(runWithExecutors.getPayload().containsKey("module_executors"));
+        assertEquals(List.of("direct_call"), runWithExecutors.getPayload().get("module_executors"));
+        assertFalse(runWithExecutors.getPayload().containsKey("executor_opts"));
+
+        runWithExecutors = runWithExecutors.withExecutors(Optional.of(List.of("splay")),
+                Optional.of(Map.of("splaytime", 30)));
+        assertTrue(runWithExecutors.getPayload().containsKey("module_executors"));
+        assertEquals(List.of("splay"), runWithExecutors.getPayload().get("module_executors"));
+        assertTrue(runWithExecutors.getPayload().containsKey("executor_opts"));
+        assertEquals(Map.of("splaytime", 30), runWithExecutors.getPayload().get("executor_opts"));
+
+        LocalCall<String> runWithoutExecutors = runWithExecutors.withoutExecutors();
+        assertFalse(runWithoutExecutors.getPayload().containsKey("module_executors"));
+        assertFalse(runWithoutExecutors.getPayload().containsKey("executor_opts"));
+        assertTrue(runWithExecutors.getPayload().containsKey("module_executors"));
+        assertEquals(List.of("splay"), runWithExecutors.getPayload().get("module_executors"));
+        assertTrue(runWithExecutors.getPayload().containsKey("executor_opts"));
+        assertEquals(Map.of("splaytime", 30), runWithExecutors.getPayload().get("executor_opts"));
+    }
+
     /**
      * Verify that system return the correct module name and function name
      */


### PR DESCRIPTION
Implement for salt LocalCall `.withExecutors()` and `.withoutExecutors()`.