### PR TITLE
migrate from javax to jakarta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 [![Build Status](https://github.com/SUSE/salt-netapi-client/actions/workflows/maven.yml/badge.svg)](https://github.com/SUSE/salt-netapi-client/actions/workflows/maven.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/com.suse.salt/salt-netapi-client)](https://mvnrepository.com/artifact/com.suse.salt/salt-netapi-client)
 
+# IMPORTANT
+Starting from v1.0.0, salt-netapi-client uses jakarta instead of javax. If you still want to use javax version, please use v0.x.x.
+
 # salt-netapi-client
 
-Java bindings for the [Salt API](http://docs.saltstack.com/en/latest/ref/netapi/all/salt.netapi.rest_cherrypy.html#module-salt.netapi.rest_cherrypy.app), please have a look at the Javadoc for [v0.21.0](http://suse.github.io/salt-netapi-client/docs/v0.21.0) or [master](http://suse.github.io/salt-netapi-client/docs/master).
+Java bindings for the [Salt API](http://docs.saltstack.com/en/latest/ref/netapi/all/salt.netapi.rest_cherrypy.html#module-salt.netapi.rest_cherrypy.app), please have a look at the Javadoc for [v1.0.0](http://suse.github.io/salt-netapi-client/docs/v1.0.0) or [master](http://suse.github.io/salt-netapi-client/docs/master).
 
 ## How to use it
 
@@ -13,7 +16,7 @@ Add the following dependency to the `pom.xml` file of your project:
 <dependency>
     <groupId>com.suse.salt</groupId>
     <artifactId>salt-netapi-client</artifactId>
-    <version>0.21.0</version>
+    <version>1.0.0</version>
 </dependency>
 ```
 
@@ -24,6 +27,8 @@ There is some basic [code examples](https://github.com/SUSE/salt-netapi-client/t
 ## Contributing
 
 Pull requests are always welcome, please see [issues](https://github.com/SUSE/salt-netapi-client/issues) for a list of things to possibly tackle.
+
+If you want to contribute to salt-netapi-client lib which use javax, please create a PR againsts 5.1 branch.
 
 Make sure you have Git commit signing enabled. If you are not doing it already, check out the [GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification).
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.suse.salt</groupId>
   <artifactId>salt-netapi-client</artifactId>
   <packaging>jar</packaging>
-  <version>0.22.0-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <name>salt-netapi-client</name>
   <url>https://github.com/SUSE/salt-netapi-client</url>
   <description>Java bindings for the Salt API</description>
@@ -138,10 +138,16 @@
       <version>4.1.3</version>
     </dependency>
     <dependency>
-      <groupId>javax.websocket</groupId>
-      <artifactId>javax.websocket-api</artifactId>
-      <version>1.1</version>
+      <groupId>jakarta.websocket</groupId>
+      <artifactId>jakarta.websocket-client-api</artifactId>
+      <version>2.2.0</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.websocket</groupId>
+      <artifactId>jakarta.websocket-api</artifactId>
+      <scope>provided</scope>
+    <version>2.2.0</version> 
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/suse/salt/netapi/event/WebSocketEventStream.java
+++ b/src/main/java/com/suse/salt/netapi/event/WebSocketEventStream.java
@@ -1,18 +1,18 @@
 package com.suse.salt.netapi.event;
 
-import javax.websocket.ClientEndpoint;
-import javax.websocket.CloseReason;
-import javax.websocket.CloseReason.CloseCodes;
-import javax.websocket.ContainerProvider;
-import javax.websocket.DeploymentException;
-import javax.websocket.EndpointConfig;
-import javax.websocket.OnClose;
-import javax.websocket.OnError;
-import javax.websocket.OnMessage;
-import javax.websocket.OnOpen;
-import javax.websocket.Session;
-import javax.websocket.WebSocketContainer;
-import javax.websocket.server.ServerEndpoint;
+import jakarta.websocket.ClientEndpoint;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.CloseReason.CloseCodes;
+import jakarta.websocket.ContainerProvider;
+import jakarta.websocket.DeploymentException;
+import jakarta.websocket.EndpointConfig;
+import jakarta.websocket.OnClose;
+import jakarta.websocket.OnError;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+import jakarta.websocket.WebSocketContainer;
+import jakarta.websocket.server.ServerEndpoint;
 
 import com.suse.salt.netapi.datatypes.Event;
 import com.suse.salt.netapi.datatypes.Token;

--- a/src/test/java/com/suse/salt/netapi/calls/CallAsyncEventsTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/CallAsyncEventsTest.java
@@ -45,7 +45,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import javax.websocket.DeploymentException;
+import jakarta.websocket.DeploymentException;
 
 /**
  * Tests for callAsync() taking an event stream to return results as they come in.

--- a/src/test/java/com/suse/salt/netapi/calls/CallAsyncEventsTestMessages.java
+++ b/src/test/java/com/suse/salt/netapi/calls/CallAsyncEventsTestMessages.java
@@ -3,7 +3,7 @@ package com.suse.salt.netapi.calls;
 import com.suse.salt.netapi.event.MockingWebSocket;
 import com.suse.salt.netapi.utils.ClientUtils;
 
-import javax.websocket.server.ServerEndpoint;
+import jakarta.websocket.server.ServerEndpoint;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 

--- a/src/test/java/com/suse/salt/netapi/event/AbstractEventsTest.java
+++ b/src/test/java/com/suse/salt/netapi/event/AbstractEventsTest.java
@@ -6,7 +6,7 @@ import org.junit.Before;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import javax.websocket.DeploymentException;
+import jakarta.websocket.DeploymentException;
 
 /**
  * Base class for running tests involving the WebSocket based event stream.

--- a/src/test/java/com/suse/salt/netapi/event/MockingWebSocket.java
+++ b/src/test/java/com/suse/salt/netapi/event/MockingWebSocket.java
@@ -4,13 +4,13 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import javax.websocket.CloseReason;
-import javax.websocket.OnClose;
-import javax.websocket.OnError;
-import javax.websocket.OnMessage;
-import javax.websocket.OnOpen;
-import javax.websocket.Session;
-import javax.websocket.server.ServerEndpoint;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.OnClose;
+import jakarta.websocket.OnError;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerEndpoint;
 
 /**
  * Server endpoint to emulate the WebSocket based stream of Salt events.

--- a/src/test/java/com/suse/salt/netapi/event/TyrusWebSocketEventsTest.java
+++ b/src/test/java/com/suse/salt/netapi/event/TyrusWebSocketEventsTest.java
@@ -5,7 +5,7 @@ import com.suse.salt.netapi.datatypes.Token;
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.websocket.CloseReason.CloseCodes;
+import jakarta.websocket.CloseReason.CloseCodes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;

--- a/src/test/java/com/suse/salt/netapi/event/TyrusWebSocketEventsTestMessages.java
+++ b/src/test/java/com/suse/salt/netapi/event/TyrusWebSocketEventsTestMessages.java
@@ -2,7 +2,7 @@ package com.suse.salt.netapi.event;
 
 import com.suse.salt.netapi.utils.ClientUtils;
 
-import javax.websocket.server.ServerEndpoint;
+import jakarta.websocket.server.ServerEndpoint;
 import java.util.stream.Stream;
 
 /**


### PR DESCRIPTION
- migrate from javax to jakarta
- jakarta version will use v1.x.x, instead javax will use v0.x.x
- javax will continue to be maintain in 5.1 branch