### PR TITLE
Fix test runtime errors when running on Java 17+

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 SUSE LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+FROM registry.opensuse.org/opensuse/tumbleweed:latest
+
+# Installing all packages
+RUN zypper refresh && \
+        zypper -n install awk bash-completion curl expect git man openssh sudo tar vim wget \
+                          nodejs24 java-25-openjdk-devel maven && \
+         zypper clean -a
+
+# Creating regular user
+RUN useradd --create-home --shell /bin/bash develop
+RUN echo "develop ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+USER develop

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+{
+    "name": "developer",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "containerEnv": {
+        "JAVA_HOME": "/usr/lib64/jvm/java-25-openjdk"
+    },
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "java.codeGeneration.hashCodeEquals.useInstanceof": true,
+                "java.codeGeneration.hashCodeEquals.useJava7Objects": true,
+                "java.compile.nullAnalysis.mode": "automatic",
+                "java.configuration.runtimes": [
+                    {
+                        "name": "JavaSE-25",
+                        "path": "/usr/lib64/jvm/java-25-openjdk",
+                        "default": true
+                    }
+                ],
+                "java.test.config": {
+                    "vmArgs": [
+                    ]
+                },
+                "java.jdt.ls.java.home": "/usr/lib64/jvm/java-25-openjdk"
+            },
+            "extensions": [
+                "redhat.java",
+                "vscjava.vscode-java-debug",
+                "shengchen.vscode-checkstyle",
+                "vscjava.vscode-java-test",
+                "vscjava.vscode-maven",
+                "vscjava.vscode-java-dependency",
+                "redhat.vscode-xml"
+            ]
+        }
+    },
+    "remoteUser": "develop"
+}

--- a/src/main/java/com/suse/salt/netapi/calls/RunnerCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/RunnerCall.java
@@ -9,7 +9,6 @@ import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.results.Return;
 
 import java.lang.reflect.Type;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +52,7 @@ public class RunnerCall<R> extends AbstractCall<R> {
      * @return information about the scheduled job
      */
     public CompletionStage<RunnerAsyncResult<R>> callAsync(final SaltClient client, AuthMethod auth) {
-        return client.call(this, Client.RUNNER_ASYNC, Optional.empty(), Collections.emptyMap(),
+        return client.call(this, Client.RUNNER_ASYNC, Optional.empty(), Map.of(),
                 new TypeToken<Return<List<RunnerAsyncResult<R>>>>(){}, auth)
                 .thenApply(wrapper -> {
                     RunnerAsyncResult<R> result = wrapper.getResult().get(0);
@@ -79,7 +78,7 @@ public class RunnerCall<R> extends AbstractCall<R> {
         @SuppressWarnings("unchecked")
         CompletionStage<Result<R>> resultCompletionStage =
                 client.call(
-                        this, Client.RUNNER, Optional.empty(), Collections.emptyMap(),
+                        this, Client.RUNNER, Optional.empty(), Map.of(),
                         (TypeToken<Return<List<Result<R>>>>) TypeToken.get(wrapperType), auth)
                         .thenApply(wrapper -> wrapper.getResult().get(0));
         return resultCompletionStage;

--- a/src/main/java/com/suse/salt/netapi/calls/WheelCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/WheelCall.java
@@ -9,7 +9,6 @@ import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.results.Return;
 
 import java.lang.reflect.Type;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,7 +53,7 @@ public class WheelCall<R> extends AbstractCall<R> {
      */
     public CompletionStage<WheelAsyncResult<R>> callAsync(final SaltClient client, AuthMethod auth) {
         return client.call(
-                this, Client.WHEEL_ASYNC, Optional.empty(), Collections.emptyMap(),
+                this, Client.WHEEL_ASYNC, Optional.empty(), Map.of(),
                 new TypeToken<Return<List<WheelAsyncResult<R>>>>(){}, auth)
                 .thenApply(wrapper -> {
                     WheelAsyncResult<R> result = wrapper.getResult().get(0);
@@ -80,7 +79,7 @@ public class WheelCall<R> extends AbstractCall<R> {
 
         @SuppressWarnings("unchecked")
         CompletionStage<WheelResult<Result<R>>> wheelResultCompletionStage =
-                client.call(this, Client.WHEEL, Optional.empty(), Collections.emptyMap(),
+                client.call(this, Client.WHEEL, Optional.empty(), Map.of(),
                         (TypeToken<Return<List<WheelResult<Result<R>>>>>)
                                 TypeToken.get(wrapperType), auth)
                         .thenApply(wrapper -> wrapper.getResult().get(0));

--- a/src/main/java/com/suse/salt/netapi/calls/modules/Cmd.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/Cmd.java
@@ -6,11 +6,9 @@ import com.suse.salt.netapi.results.CmdResult;
 import com.google.gson.reflect.TypeToken;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
 
 /**
  * salt.modules.cmdmod
@@ -21,36 +19,36 @@ public class Cmd {
 
     public static LocalCall<CmdResult> execCodeAll(String lang, String code) {
         return new LocalCall<>("cmd.exec_code_all", Optional.of(Arrays.asList(lang, code)),
-                Optional.of(emptyMap()), new TypeToken<CmdResult>(){});
+                Optional.of(Map.of()), new TypeToken<CmdResult>(){});
     }
 
     public static LocalCall<String> run(String cmd) {
-        return new LocalCall<>("cmd.run", Optional.empty(), Optional.of(singletonMap("cmd", cmd)),
+        return new LocalCall<>("cmd.run", Optional.empty(), Optional.of(Map.of("cmd", cmd)),
                 new TypeToken<String>(){});
     }
 
     public static LocalCall<CmdResult> runAll(String cmd) {
-        return new LocalCall<>("cmd.run_all", Optional.empty(), Optional.of(singletonMap("cmd", cmd)),
+        return new LocalCall<>("cmd.run_all", Optional.empty(), Optional.of(Map.of("cmd", cmd)),
                 new TypeToken<CmdResult>(){});
     }
 
     public static LocalCall<String> execCode(String lang, String code) {
         return new LocalCall<>("cmd.exec_code", Optional.of(Arrays.asList(lang, code)),
-                Optional.of(emptyMap()), new TypeToken<String>(){});
+                Optional.of(Map.of()), new TypeToken<String>(){});
     }
 
     public static LocalCall<Boolean> hasExec(String cmd) {
-        return new LocalCall<>("cmd.has_exec", Optional.empty(), Optional.of(singletonMap("cmd", cmd)),
+        return new LocalCall<>("cmd.has_exec", Optional.empty(), Optional.of(Map.of("cmd", cmd)),
                 new TypeToken<Boolean>(){});
     }
 
     public static LocalCall<CmdResult> script(String source) {
-        return new LocalCall<>("cmd.script", Optional.of(singletonList(source)), Optional.of(emptyMap()),
+        return new LocalCall<>("cmd.script", Optional.of(List.of(source)), Optional.of(Map.of()),
                 new TypeToken<CmdResult>(){});
     }
 
     public static LocalCall<Integer> scriptRetcode(String source) {
-        return new LocalCall<>("cmd.script_retcode", Optional.of(singletonList(source)), Optional.of(emptyMap()),
+        return new LocalCall<>("cmd.script_retcode", Optional.of(List.of(source)), Optional.of(Map.of()),
                 new TypeToken<Integer>(){});
     }
 }

--- a/src/main/java/com/suse/salt/netapi/calls/modules/File.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/File.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Optional;
 
 /**
@@ -105,7 +104,7 @@ public class File {
      * @return      The {@link LocalCall} object to make the call
      */
     public static LocalCall<Boolean> remove(String path) {
-        return new LocalCall<>("file.remove", Optional.of(Collections.singletonList(path)),
+        return new LocalCall<>("file.remove", Optional.of(List.of(path)),
                 Optional.empty(), new TypeToken<Boolean>(){});
     }
 
@@ -302,7 +301,7 @@ public class File {
      * @return      The {@link LocalCall} object to make the call
      */
     public static LocalCall<List<String>> readdir(String path) {
-        return new LocalCall<>("file.readdir", Optional.of(Collections.singletonList(path)),
+        return new LocalCall<>("file.readdir", Optional.of(List.of(path)),
                 Optional.empty(), new TypeToken<List<String>>(){});
     }
 
@@ -315,7 +314,7 @@ public class File {
      * @return      The {@link LocalCall} object to make the call
      */
     public static LocalCall<Boolean> rmdir(String path) {
-        return new LocalCall<>("file.rmdir", Optional.of(Collections.singletonList(path)),
+        return new LocalCall<>("file.rmdir", Optional.of(List.of(path)),
                 Optional.empty(), new TypeToken<Boolean>(){});
     }
 
@@ -326,7 +325,7 @@ public class File {
      * @return      The {@link LocalCall} object to make the call
      */
     public static LocalCall<Boolean> isLink(String path) {
-        return new LocalCall<>("file.is_link", Optional.of(Collections.singletonList(path)),
+        return new LocalCall<>("file.is_link", Optional.of(List.of(path)),
                 Optional.empty(), new TypeToken<Boolean>(){});
     }
 

--- a/src/main/java/com/suse/salt/netapi/calls/modules/Git.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/Git.java
@@ -7,9 +7,8 @@ import com.google.gson.reflect.TypeToken;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-
-import static java.util.Collections.emptyMap;
 
 /**
  * salt.modules.git
@@ -22,7 +21,7 @@ public class Git {
         List<String> args = new ArrayList<>(Arrays.asList(cwd));
         user.ifPresent(usr -> args.add(usr));
         return new LocalCall<>("git.status", Optional.of(args),
-                Optional.of(emptyMap()), new TypeToken<GitResult>(){});
+                Optional.of(Map.of()), new TypeToken<GitResult>(){});
     }
 
     public static LocalCall<String> add(String cwd, String filename,
@@ -30,7 +29,7 @@ public class Git {
         List<String> args = new ArrayList<>(Arrays.asList(cwd, filename, opts, gitOpts));
         user.ifPresent(usr -> args.add(usr));
         return new LocalCall<>("git.add", Optional.of(args),
-                Optional.of(emptyMap()), new TypeToken<String>(){});
+                Optional.of(Map.of()), new TypeToken<String>(){});
     }
 
     public static LocalCall<String> commit(String cwd, String message,
@@ -39,7 +38,7 @@ public class Git {
         user.ifPresent(usr -> args.add(usr));
         filename.ifPresent(file -> args.add(file));
         return new LocalCall<>("git.commit", Optional.of(args),
-                Optional.of(emptyMap()), new TypeToken<String>(){});
+                Optional.of(Map.of()), new TypeToken<String>(){});
     }
 
     public static LocalCall<Boolean> branch(String cwd, String branch,
@@ -47,7 +46,7 @@ public class Git {
         List<String> args = new ArrayList<>(Arrays.asList(cwd, branch, opts, gitOpts));
         user.ifPresent(usr -> args.add(usr));
         return new LocalCall<>("git.branch", Optional.of(args),
-                Optional.of(emptyMap()), new TypeToken<Boolean>(){});
+                Optional.of(Map.of()), new TypeToken<Boolean>(){});
     }
 
     public static LocalCall<Boolean> clone(String cwd, String url, Optional<String> name, String opts, String gitOpts,
@@ -64,7 +63,7 @@ public class Git {
         args.add(httpsPass.orElse(null));
 
         LocalCall<Boolean> run = new LocalCall<>(
-                "git.clone", Optional.of(args), Optional.of(emptyMap()), new TypeToken<Boolean>(){});
+                "git.clone", Optional.of(args), Optional.of(Map.of()), new TypeToken<Boolean>(){});
         // set a higher timeout if HTTPS user and pass are given, otherwise no timeout
         if (httpsUser.isPresent()) {
             return run.withTimeouts(Optional.of(4), Optional.of(1));

--- a/src/main/java/com/suse/salt/netapi/calls/modules/Pkg.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/Pkg.java
@@ -9,7 +9,6 @@ import com.google.gson.reflect.TypeToken;
 
 import java.time.ZonedDateTime;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -410,9 +409,7 @@ public class Pkg {
      */
     private static List<Map<String, String>> preparePkgs(Map<String, String> pkgs) {
         return pkgs.entrySet().stream()
-                .map(e -> Collections.unmodifiableMap(Stream.of(e)
-                        .collect(Collectors.<Map.Entry<String, String>, String, String>
-                                toMap(Map.Entry::getKey, Map.Entry::getValue))))
+                .map(e -> Stream.of(e).collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue)))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/suse/salt/netapi/calls/modules/Status.java
+++ b/src/main/java/com/suse/salt/netapi/calls/modules/Status.java
@@ -5,7 +5,6 @@ import com.suse.salt.netapi.calls.LocalCall;
 import com.google.gson.reflect.TypeToken;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -75,8 +74,7 @@ public class Status {
     }
 
     public static LocalCall<String> pid(String signature) {
-        List<String> args = Collections.singletonList(signature);
-        return new LocalCall<>("status.pid", Optional.of(args), Optional.empty(),
+        return new LocalCall<>("status.pid", Optional.of(List.of(signature)), Optional.empty(),
                 new TypeToken<String>(){});
     }
 

--- a/src/main/java/com/suse/salt/netapi/client/AsyncHttpClient.java
+++ b/src/main/java/com/suse/salt/netapi/client/AsyncHttpClient.java
@@ -3,7 +3,6 @@ package com.suse.salt.netapi.client;
 import com.suse.salt.netapi.parser.JsonParser;
 
 import java.net.URI;
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
@@ -32,7 +31,7 @@ public interface AsyncHttpClient {
      * @return CompletionStage holding object of the given return type T
      */
     default <T>  CompletionStage<T> get(URI uri, JsonParser<T> parser) {
-        return get(uri, Collections.emptyMap(), parser);
+        return get(uri, Map.of(), parser);
     }
 
     /**
@@ -57,6 +56,6 @@ public interface AsyncHttpClient {
      * @return CompletionStage holding object of the given return type T
      */
     default <T> CompletionStage<T> post(URI uri, String data, JsonParser<T> parser) {
-        return post(uri, Collections.emptyMap(), data, parser);
+        return post(uri, Map.of(), data, parser);
     }
 }

--- a/src/main/java/com/suse/salt/netapi/client/SaltClient.java
+++ b/src/main/java/com/suse/salt/netapi/client/SaltClient.java
@@ -20,7 +20,6 @@ import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.results.SSHRawResult;
 
 import java.net.URI;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -122,9 +121,7 @@ public class SaltClient {
         props.put("arg", args);
         props.put("kwarg", kwargs);
 
-        List<Map<String, Object>> list =  Collections.singletonList(props);
-
-        String payload = gson.toJson(list);
+        String payload = gson.toJson(List.of(props));
 
         CompletionStage<Map<String, Object>> result = asyncHttpClient
                 .post(uri.resolve("run"), payload, JsonParser.RUN_RESULTS)
@@ -153,9 +150,7 @@ public class SaltClient {
 
         SaltSSHUtils.mapConfigPropsToArgs(cfg, props);
 
-        List<Map<String, Object>> list = Collections.singletonList(props);
-
-        String payload = gson.toJson(list);
+        String payload = gson.toJson(List.of(props));
 
         CompletionStage<Map<String, Result<SSHRawResult>>> result = asyncHttpClient
                 .post(uri.resolve("run"), payload, JsonParser.RUNSSHRAW_RESULTS)
@@ -217,8 +212,7 @@ public class SaltClient {
         props.put("client", client.getValue());
         props.putAll(call.getPayload());
         props.putAll(custom);
-        List<Map<String, Object>> list = Collections.singletonList(props);
-        String payload = gson.toJson(list);
+        String payload = gson.toJson(List.of(props));
 
         URI endpoint = auth.getInternal().isRight() ? uri.resolve("run") : uri;
         return asyncHttpClient.post(endpoint, headers, payload, new JsonParser<>(type));

--- a/src/test/java/com/suse/salt/netapi/calls/modules/ScheduleTest.java
+++ b/src/test/java/com/suse/salt/netapi/calls/modules/ScheduleTest.java
@@ -30,7 +30,6 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -111,7 +110,7 @@ public class ScheduleTest {
                 scheduleDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
         LocalCall<com.suse.salt.netapi.calls.modules.Schedule.Result> call =
                 Schedule.add("Test Job", com.suse.salt.netapi.calls.modules.Test.ping(),
-                        scheduleDate, Collections.EMPTY_MAP);
+                        scheduleDate, Map.of());
         Map<String, Object> kwarg = (Map<String, Object>) call.getPayload().get("kwarg");
         assertEquals("2017-12-24T15:30:12", kwarg.get("once"));
     }


### PR DESCRIPTION
This PR replace the usages of `emptyMap()`, `singletonMap()` and `singletonList()` with the respective collection factory method. This avoids issue with gson serialization and private access on virtual machines that [enforce strong encapsulation](https://openjdk.org/jeps/403).