### PR TITLE
Pin GitHub Actions to SHA checksums

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,9 +26,9 @@ jobs:
         options: --name saltminion2 --link saltmaster:salt
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up JDK 11
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'zulu'
           java-version: '11'
@@ -36,7 +36,7 @@ jobs:
         run: mvn checkstyle:check javadoc:javadoc test package
       - name: Get branch name or tag
         if: success()
-        uses: tj-actions/branch-names@dde14ac574a8b9b1cedc59a1cf312788af43d8d8 # v8.2.1
+        uses: tj-actions/branch-names@5250492686b253f06fa55861556d1027b067aeb5 # v9.0.2
         id: branch-name
       - name: Publish javadoc for the default branch
         if: success() && steps.branch-name.outputs.is_default == 'true'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,9 +26,9 @@ jobs:
         options: --name saltminion2 --link saltmaster:salt
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: 'zulu'
           java-version: '11'
@@ -36,11 +36,11 @@ jobs:
         run: mvn checkstyle:check javadoc:javadoc test package
       - name: Get branch name or tag
         if: success()
-        uses: tj-actions/branch-names@v8
+        uses: tj-actions/branch-names@dde14ac574a8b9b1cedc59a1cf312788af43d8d8 # v8.2.1
         id: branch-name
       - name: Publish javadoc for the default branch
         if: success() && steps.branch-name.outputs.is_default == 'true'
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/apidocs
@@ -49,7 +49,7 @@ jobs:
           user_email: 'github-actions[bot]@users.noreply.github.com'
       - name: Publish javadoc for a tagged release
         if: success() && steps.branch-name.outputs.is_tag == 'true'
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/apidocs
@@ -58,7 +58,7 @@ jobs:
           user_email: 'github-actions[bot]@users.noreply.github.com'
       - name: Create tagged release
         if: success() && steps.branch-name.outputs.is_tag == 'true'
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: false


### PR DESCRIPTION
## Summary

  Pin all GitHub Actions references to their full SHA checksums to prevent supply chain attacks via tag
  manipulation, and update actions to latest versions where available.

  ### Actions pinned and updated

  | Action | Previous | Current | SHA |
  |--------|----------|---------|-----|
  | `actions/checkout` | v4 | v6.0.2 | `de0fac2e` |
  | `actions/setup-java` | v4 | v5.2.0 | `be666c2f` |
  | `tj-actions/branch-names` | v8 | v9.0.2 | `52504926` |
  | `peaceiris/actions-gh-pages` | v4 | v4.0.0 | `4f9cc660` |
  | `marvinpinto/action-automatic-releases` | latest | v1.2.1 | `919008cf` |

  Version comments are included inline for easy identification during future updates.

  **Note:** All SHA checksums were verified manually against their corresponding release tags.