### PR TITLE
Migrate usage of internal GSON API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.9</version>
+      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.14.0</version>
+      <version>2.8.9</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/LocalCall.java
@@ -174,9 +174,14 @@ public class LocalCall<R> extends AbstractCall<R> {
         Map<String, Object> customArgs = new HashMap<>();
         batch.ifPresent(v -> customArgs.putAll(v.getParams()));
 
+        Type asyncResultType = parameterizedType(null, LocalAsyncResult.class, getReturnType().getType());
+        Type listType = parameterizedType(null, List.class, asyncResultType);
+        Type wrapperType = parameterizedType(null, Return.class, listType);
+        @SuppressWarnings("unchecked")
+        TypeToken<Return<List<LocalAsyncResult<R>>>> typeToken =
+                (TypeToken<Return<List<LocalAsyncResult<R>>>>) TypeToken.get(wrapperType);
         return client.call(
-                this, Client.LOCAL_ASYNC, Optional.of(target), customArgs,
-                new TypeToken<Return<List<LocalAsyncResult<R>>>>(){}, auth)
+                this, Client.LOCAL_ASYNC, Optional.of(target), customArgs, typeToken, auth)
                 .thenApply(wrapper -> {
                     LocalAsyncResult<R> result = wrapper.getResult().get(0);
                     result.setType(getReturnType());

--- a/src/main/java/com/suse/salt/netapi/calls/RunnerCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/RunnerCall.java
@@ -52,8 +52,13 @@ public class RunnerCall<R> extends AbstractCall<R> {
      * @return information about the scheduled job
      */
     public CompletionStage<RunnerAsyncResult<R>> callAsync(final SaltClient client, AuthMethod auth) {
-        return client.call(this, Client.RUNNER_ASYNC, Optional.empty(), Map.of(),
-                new TypeToken<Return<List<RunnerAsyncResult<R>>>>(){}, auth)
+        Type asyncResultType = parameterizedType(null, RunnerAsyncResult.class, getReturnType().getType());
+        Type listType = parameterizedType(null, List.class, asyncResultType);
+        Type wrapperType = parameterizedType(null, Return.class, listType);
+        @SuppressWarnings("unchecked")
+        TypeToken<Return<List<RunnerAsyncResult<R>>>> typeToken =
+                (TypeToken<Return<List<RunnerAsyncResult<R>>>>) TypeToken.get(wrapperType);
+        return client.call(this, Client.RUNNER_ASYNC, Optional.empty(), Map.of(), typeToken, auth)
                 .thenApply(wrapper -> {
                     RunnerAsyncResult<R> result = wrapper.getResult().get(0);
                     result.setType(getReturnType());

--- a/src/main/java/com/suse/salt/netapi/calls/WheelCall.java
+++ b/src/main/java/com/suse/salt/netapi/calls/WheelCall.java
@@ -52,9 +52,14 @@ public class WheelCall<R> extends AbstractCall<R> {
      * @return information about the scheduled job
      */
     public CompletionStage<WheelAsyncResult<R>> callAsync(final SaltClient client, AuthMethod auth) {
+        Type asyncResultType = parameterizedType(null, WheelAsyncResult.class, getReturnType().getType());
+        Type listType = parameterizedType(null, List.class, asyncResultType);
+        Type wrapperType = parameterizedType(null, Return.class, listType);
+        @SuppressWarnings("unchecked")
+        TypeToken<Return<List<WheelAsyncResult<R>>>> typeToken =
+                (TypeToken<Return<List<WheelAsyncResult<R>>>>) TypeToken.get(wrapperType);
         return client.call(
-                this, Client.WHEEL_ASYNC, Optional.empty(), Map.of(),
-                new TypeToken<Return<List<WheelAsyncResult<R>>>>(){}, auth)
+                this, Client.WHEEL_ASYNC, Optional.empty(), Map.of(), typeToken, auth)
                 .thenApply(wrapper -> {
                     WheelAsyncResult<R> result = wrapper.getResult().get(0);
                     result.setType(getReturnType());

--- a/src/main/java/com/suse/salt/netapi/parser/CollectionTypeAdapterFactory.java
+++ b/src/main/java/com/suse/salt/netapi/parser/CollectionTypeAdapterFactory.java
@@ -4,28 +4,29 @@ import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
-import com.google.gson.internal.$Gson$Types;
-import com.google.gson.internal.ConstructorConstructor;
-import com.google.gson.internal.ObjectConstructor;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Queue;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.function.Supplier;
 
 /**
  * Adapt a homogeneous collection of objects.
  */
 public class CollectionTypeAdapterFactory implements TypeAdapterFactory {
-    private final ConstructorConstructor constructorConstructor;
-
-    public CollectionTypeAdapterFactory() {
-        this.constructorConstructor = new ConstructorConstructor(new HashMap<>());
-    }
 
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
         Type type = typeToken.getType();
@@ -34,14 +35,45 @@ public class CollectionTypeAdapterFactory implements TypeAdapterFactory {
         if (!Collection.class.isAssignableFrom(rawType)) {
             return null;
         }
-        Type elementType = $Gson$Types.getCollectionElementType(type, rawType);
+        Type elementType = collectionElementType(type);
 
         TypeAdapter<?> elementTypeAdapter = gson.getAdapter(TypeToken.get(elementType));
-        ObjectConstructor<T> constructor = constructorConstructor.get(typeToken);
+        Supplier<Collection<?>> constructor = collectionSupplier(rawType);
 
         @SuppressWarnings({ "unchecked", "rawtypes" })
         TypeAdapter<T> result = new Adapter(elementTypeAdapter, constructor);
         return result;
+    }
+
+    /**
+     * Returns the element type of a Collection parameterized type.
+     * Handles wildcard upper bounds (e.g. {@code Collection<? extends Foo>}).
+     */
+    private static Type collectionElementType(Type type) {
+        if (type instanceof ParameterizedType) {
+            Type arg = ((ParameterizedType) type).getActualTypeArguments()[0];
+            if (arg instanceof WildcardType) {
+                return ((WildcardType) arg).getUpperBounds()[0];
+            }
+            return arg;
+        }
+        return Object.class;
+    }
+
+    /**
+     * Returns a {@link Supplier} that creates a suitable mutable {@link Collection}
+     * instance for the given raw collection type.
+     */
+    private static Supplier<Collection<?>> collectionSupplier(Class<?> rawType) {
+        if (SortedSet.class.isAssignableFrom(rawType)) {
+            return TreeSet::new;
+        } else if (Set.class.isAssignableFrom(rawType)) {
+            return LinkedHashSet::new;
+        } else if (Queue.class.isAssignableFrom(rawType)) {
+            return ArrayDeque::new;
+        } else {
+            return ArrayList::new;
+        }
     }
 
     /**
@@ -50,11 +82,11 @@ public class CollectionTypeAdapterFactory implements TypeAdapterFactory {
      */
     private static final class Adapter<E> extends TypeAdapter<Collection<E>> {
         private final TypeAdapter<E> elementTypeAdapter;
-        private final ObjectConstructor<? extends Collection<E>> constructor;
+        private final Supplier<Collection<E>> constructor;
 
-        public Adapter(TypeAdapter<E> elementAdapter, ObjectConstructor<? extends
-                Collection<E>> constructor) {
-            this.constructor = constructor;
+        @SuppressWarnings("unchecked")
+        public Adapter(TypeAdapter<E> elementAdapter, Supplier<?> constructor) {
+            this.constructor = (Supplier<Collection<E>>) constructor;
             this.elementTypeAdapter = elementAdapter;
         }
 
@@ -63,7 +95,7 @@ public class CollectionTypeAdapterFactory implements TypeAdapterFactory {
                 throw new JsonParseException("null is not a valid value for a Collection");
             }
 
-            Collection<E> collection = constructor.construct();
+            Collection<E> collection = constructor.get();
             in.beginArray();
             while (in.hasNext()) {
                 E instance = elementTypeAdapter.read(in);

--- a/src/main/java/com/suse/salt/netapi/parser/OptionalTypeAdapterFactory.java
+++ b/src/main/java/com/suse/salt/netapi/parser/OptionalTypeAdapterFactory.java
@@ -2,10 +2,10 @@ package com.suse.salt.netapi.parser;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
-import com.google.gson.internal.bind.TypeAdapters;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
@@ -44,7 +44,7 @@ public class OptionalTypeAdapterFactory implements TypeAdapterFactory {
                     in.nextNull();
                     return Optional.empty();
                 } else {
-                    JsonElement json = TypeAdapters.JSON_ELEMENT.read(in);
+                    JsonElement json = JsonParser.parseReader(in);
                     try {
                         A value = innerAdapter.fromJsonTree(json);
                         return Optional.of(value);

--- a/src/main/java/com/suse/salt/netapi/parser/ResultSSHResultTypeAdapterFactory.java
+++ b/src/main/java/com/suse/salt/netapi/parser/ResultSSHResultTypeAdapterFactory.java
@@ -5,7 +5,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
-import com.google.gson.internal.bind.TypeAdapters;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
@@ -22,6 +21,7 @@ import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 
+import static com.google.gson.JsonParser.parseReader;
 import static com.suse.salt.netapi.utils.ClientUtils.parameterizedType;
 
 /**
@@ -66,7 +66,7 @@ public class ResultSSHResultTypeAdapterFactory implements TypeAdapterFactory {
         return new TypeAdapter<Result<SSHResult<R>>>() {
             @Override
             public Result<SSHResult<R>> read(JsonReader in) throws IOException {
-                JsonElement json = TypeAdapters.JSON_ELEMENT.read(in);
+                JsonElement json = parseReader(in);
                 try {
                     SSHResult<R> value = innerAdapter.fromJsonTree(json);
                     if (!value.getReturn().isPresent() && value.getRetcode() != 0) {

--- a/src/main/java/com/suse/salt/netapi/parser/XorTypeAdapterFactory.java
+++ b/src/main/java/com/suse/salt/netapi/parser/XorTypeAdapterFactory.java
@@ -5,7 +5,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
-import com.google.gson.internal.bind.TypeAdapters;
+import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
@@ -72,7 +72,7 @@ public class XorTypeAdapterFactory implements TypeAdapterFactory {
         return new TypeAdapter<Xor<L, R>>() {
             @Override
             public Xor<L, R> read(JsonReader in) throws IOException {
-                JsonElement json = TypeAdapters.JSON_ELEMENT.read(in);
+                JsonElement json = JsonParser.parseReader(in);
                 try {
                     R value = rightAdapter.fromJsonTree(json);
                     return Xor.right(value);
@@ -101,7 +101,7 @@ public class XorTypeAdapterFactory implements TypeAdapterFactory {
         return new TypeAdapter<Xor<SaltError, R>>() {
             @Override
             public Xor<SaltError, R> read(JsonReader in) throws IOException {
-                JsonElement json = TypeAdapters.JSON_ELEMENT.read(in);
+                JsonElement json = JsonParser.parseReader(in);
                 try {
                     R value = innerAdapter.fromJsonTree(json);
                     return Xor.right(value);

--- a/src/test/java/com/suse/salt/netapi/client/SaltClientDockerTest.java
+++ b/src/test/java/com/suse/salt/netapi/client/SaltClientDockerTest.java
@@ -144,7 +144,7 @@ public class SaltClientDockerTest {
         assertNotNull(results);
         assertEquals(2, results.size());
         results.forEach((minion, result) -> {
-            assertEquals("3002.2", result.result().get().getSalt().get("Salt"));
+            assertEquals("3006.0", result.result().get().getSalt().get("Salt"));
         });
     }
 }


### PR DESCRIPTION
Closes #323

- migrate usages of the `com.google.gson.internal` packages to support the usage of newer GSON versions